### PR TITLE
Node weights and property

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/DijkstraProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/DijkstraProc.java
@@ -47,7 +47,7 @@ public class DijkstraProc {
         final Graph graph = new GraphLoader(api)
                 .withOptionalLabel((String) config.get(CONFIG_LABEL))
                 .withOptionalRelationshipType((String) config.get(CONFIG_RELATIONSHIP))
-                .withOptionalWeightsFromProperty(
+                .withOptionalRelationshipWeightsFromProperty(
                         propertyName,
                         (double) config.getOrDefault(CONFIG_DEFAULT_VALUE, 1.0))
                 .withExecutorService(Pools.DEFAULT)
@@ -76,7 +76,7 @@ public class DijkstraProc {
         final Graph graph = new GraphLoader(api)
                 .withOptionalLabel((String) config.get(CONFIG_LABEL))
                 .withOptionalRelationshipType((String) config.get(CONFIG_RELATIONSHIP))
-                .withOptionalWeightsFromProperty(
+                .withOptionalRelationshipWeightsFromProperty(
                         propertyName,
                         (double) config.getOrDefault(CONFIG_DEFAULT_VALUE, 1.0))
                 .withExecutorService(Pools.DEFAULT)

--- a/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
@@ -103,7 +103,7 @@ public final class PageRankProc {
         Graph graph = new GraphLoader(api)
                 .withOptionalLabel(label)
                 .withOptionalRelationshipType(relationship)
-                .withoutWeights()
+                .withoutRelationshipWeights()
                 .withExecutorService(Pools.DEFAULT)
                 .load(HeavyGraphFactory.class);
         statsBuilder

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
@@ -87,7 +87,7 @@ public class UnionFindProc {
         return new GraphLoader(api)
                 .withOptionalLabel(label)
                 .withOptionalRelationshipType(relationship)
-                .withOptionalWeightsFromProperty(
+                .withOptionalRelationshipWeightsFromProperty(
                         (String) config.get(CONFIG_PROPERTY),
                         (double)config.getOrDefault(CONFIG_DEFAULT_VALUE, 1.0))
                 .withExecutorService(Pools.DEFAULT)

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/MSTPrim.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/MSTPrim.java
@@ -2,11 +2,8 @@ package org.neo4j.graphalgo.impl;
 
 import com.carrotsearch.hppc.*;
 import org.neo4j.graphalgo.api.*;
-import org.neo4j.graphalgo.core.sources.BothRelationshipAdapter;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.container.SubGraph;
 import org.neo4j.graphalgo.core.utils.queue.LongMinPriorityQueue;
-import org.neo4j.graphdb.Direction;
 
 import static org.neo4j.graphalgo.core.utils.RawValues.*;
 
@@ -19,9 +16,9 @@ public class MSTPrim {
 
     private final IdMapping idMapping;
     private final BothRelationshipIterator iterator;
-    private final Weights weights;
+    private final RelationshipWeights weights;
 
-    public MSTPrim(IdMapping idMapping, BothRelationshipIterator iterator, Weights weights) {
+    public MSTPrim(IdMapping idMapping, BothRelationshipIterator iterator, RelationshipWeights weights) {
         this.idMapping = idMapping;
         this.iterator = iterator;
         this.weights = weights;

--- a/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
@@ -24,6 +24,10 @@ public class GraphSetup {
     public final String nodeWeightPropertyName;
     // default property is used for weighted nodes if property is not set.
     public final double nodeDefaultWeight;
+    // additional node property. null means NO property (the default value will be used instead).
+    public final String nodePropertyName;
+    // default property is used for node properties if property is not set.
+    public final double nodeDefaultPropertyValue;
 
     // the executor service for parallel execution. null means single threaded evaluation.
     @Deprecated
@@ -40,6 +44,9 @@ public class GraphSetup {
      * @param nodeWeightPropertyName property name which holds the weights / costs of a node.
      *                               null means the default value is used for each weight.
      * @param nodeDefaultWeight the default node weight if property is not given.
+     * @param nodePropertyName property name which holds additional values of a node.
+     *                         null means the default value is used for each value.
+     * @param nodeDefaultPropertyValue the default node value if property is not given.
      * @param executor the executor. null means single threaded evaluation
      */
     public GraphSetup(
@@ -50,6 +57,8 @@ public class GraphSetup {
             double relationDefaultWeight,
             String nodeWeightPropertyName,
             double nodeDefaultWeight,
+            String nodePropertyName,
+            double nodeDefaultPropertyValue,
             ExecutorService executor) {
 
         this.startLabel = startLabel;
@@ -59,6 +68,8 @@ public class GraphSetup {
         this.relationDefaultWeight = relationDefaultWeight;
         this.nodeWeightPropertyName = nodeWeightPropertyName;
         this.nodeDefaultWeight = nodeDefaultWeight;
+        this.nodePropertyName = nodePropertyName;
+        this.nodeDefaultPropertyValue = nodeDefaultPropertyValue;
         this.executor = executor;
     }
 
@@ -73,6 +84,8 @@ public class GraphSetup {
         this.relationDefaultWeight = 1.0;
         this.nodeWeightPropertyName = null;
         this.nodeDefaultWeight = 1.0;
+        this.nodePropertyName = null;
+        this.nodeDefaultPropertyValue = 1.0;
         this.executor = null;
     }
 
@@ -90,6 +103,8 @@ public class GraphSetup {
         this.relationDefaultWeight = 1.0;
         this.nodeWeightPropertyName = null;
         this.nodeDefaultWeight = 1.0;
+        this.nodePropertyName = null;
+        this.nodeDefaultPropertyValue = 1.0;
         this.executor = executor;
     }
 
@@ -103,6 +118,10 @@ public class GraphSetup {
 
     public boolean loadDefaultNodeWeight() {
         return nodeWeightPropertyName == null;
+    }
+
+    public boolean loadDefaultNodeProperty() {
+        return nodePropertyName == null;
     }
 
     public boolean loadAnyLabel() {

--- a/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
@@ -16,10 +16,10 @@ public class GraphSetup {
     public final String endLabel;
     // relationtype name. null means any relation.
     public final String relationshipType;
-    // propertyName. null means NO property (the default value will be used instead).
-    public final String propertyName;
+    // property of relationship weights. null means NO property (the default value will be used instead).
+    public final String relationWeightPropertyName;
     // default property is used for weighted relationships if property is not set.
-    public final double propertyDefaultValue;
+    public final double relationDefaultWeight;
 
     // the executor service for parallel execution. null means single threaded evaluation.
     @Deprecated
@@ -30,24 +30,24 @@ public class GraphSetup {
      * @param startLabel the start label. null means any label.
      * @param endLabel not implemented yet
      * @param relationshipType the relation type identifier. null for any relationship
-     * @param propertyName property name which holds the weights / costs of a relation.
-     *                     null means the default value is used for each weight.
-     * @param propertyDefaultValue the default value if property is not given.
+     * @param relationWeightPropertyName property name which holds the weights / costs of a relation.
+     *                                   null means the default value is used for each weight.
+     * @param relationDefaultWeight the default relationship weight if property is not given.
      * @param executor the executor. null means single threaded evaluation
      */
     public GraphSetup(
             String startLabel,
             String endLabel,
             String relationshipType,
-            String propertyName,
-            double propertyDefaultValue,
+            String relationWeightPropertyName,
+            double relationDefaultWeight,
             ExecutorService executor) {
 
         this.startLabel = startLabel;
         this.endLabel = endLabel;
         this.relationshipType = relationshipType;
-        this.propertyName = propertyName;
-        this.propertyDefaultValue = propertyDefaultValue;
+        this.relationWeightPropertyName = relationWeightPropertyName;
+        this.relationDefaultWeight = relationDefaultWeight;
         this.executor = executor;
     }
 
@@ -58,8 +58,8 @@ public class GraphSetup {
         this.startLabel = null;
         this.endLabel = null;
         this.relationshipType = null;
-        this.propertyName = null;
-        this.propertyDefaultValue = 0.0;
+        this.relationWeightPropertyName = null;
+        this.relationDefaultWeight = 1.0;
         this.executor = null;
     }
 
@@ -73,8 +73,8 @@ public class GraphSetup {
         this.startLabel = null;
         this.endLabel = null;
         this.relationshipType = null;
-        this.propertyName = null;
-        this.propertyDefaultValue = 0.0;
+        this.relationWeightPropertyName = null;
+        this.relationDefaultWeight = 1.0;
         this.executor = executor;
     }
 
@@ -82,8 +82,8 @@ public class GraphSetup {
         return executor != null;
     }
 
-    public boolean loadAnyProperty() {
-        return propertyName == null;
+    public boolean loadDefaultRelationshipWeight() {
+        return relationWeightPropertyName == null;
     }
 
     public boolean loadAnyLabel() {

--- a/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/GraphSetup.java
@@ -20,6 +20,10 @@ public class GraphSetup {
     public final String relationWeightPropertyName;
     // default property is used for weighted relationships if property is not set.
     public final double relationDefaultWeight;
+    // property of node weights. null means NO property (the default value will be used instead).
+    public final String nodeWeightPropertyName;
+    // default property is used for weighted nodes if property is not set.
+    public final double nodeDefaultWeight;
 
     // the executor service for parallel execution. null means single threaded evaluation.
     @Deprecated
@@ -33,6 +37,9 @@ public class GraphSetup {
      * @param relationWeightPropertyName property name which holds the weights / costs of a relation.
      *                                   null means the default value is used for each weight.
      * @param relationDefaultWeight the default relationship weight if property is not given.
+     * @param nodeWeightPropertyName property name which holds the weights / costs of a node.
+     *                               null means the default value is used for each weight.
+     * @param nodeDefaultWeight the default node weight if property is not given.
      * @param executor the executor. null means single threaded evaluation
      */
     public GraphSetup(
@@ -41,6 +48,8 @@ public class GraphSetup {
             String relationshipType,
             String relationWeightPropertyName,
             double relationDefaultWeight,
+            String nodeWeightPropertyName,
+            double nodeDefaultWeight,
             ExecutorService executor) {
 
         this.startLabel = startLabel;
@@ -48,6 +57,8 @@ public class GraphSetup {
         this.relationshipType = relationshipType;
         this.relationWeightPropertyName = relationWeightPropertyName;
         this.relationDefaultWeight = relationDefaultWeight;
+        this.nodeWeightPropertyName = nodeWeightPropertyName;
+        this.nodeDefaultWeight = nodeDefaultWeight;
         this.executor = executor;
     }
 
@@ -60,6 +71,8 @@ public class GraphSetup {
         this.relationshipType = null;
         this.relationWeightPropertyName = null;
         this.relationDefaultWeight = 1.0;
+        this.nodeWeightPropertyName = null;
+        this.nodeDefaultWeight = 1.0;
         this.executor = null;
     }
 
@@ -75,6 +88,8 @@ public class GraphSetup {
         this.relationshipType = null;
         this.relationWeightPropertyName = null;
         this.relationDefaultWeight = 1.0;
+        this.nodeWeightPropertyName = null;
+        this.nodeDefaultWeight = 1.0;
         this.executor = executor;
     }
 
@@ -84,6 +99,10 @@ public class GraphSetup {
 
     public boolean loadDefaultRelationshipWeight() {
         return relationWeightPropertyName == null;
+    }
+
+    public boolean loadDefaultNodeWeight() {
+        return nodeWeightPropertyName == null;
     }
 
     public boolean loadAnyLabel() {

--- a/core/src/main/java/org/neo4j/graphalgo/api/NodeProperties.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/NodeProperties.java
@@ -1,0 +1,9 @@
+package org.neo4j.graphalgo.api;
+
+/**
+ * @author mknblch
+ */
+public interface NodeProperties {
+
+    double valueOf(int nodeId, double defaultValue);
+}

--- a/core/src/main/java/org/neo4j/graphalgo/api/NodeWeights.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/NodeWeights.java
@@ -1,0 +1,9 @@
+package org.neo4j.graphalgo.api;
+
+/**
+ * @author mknblch
+ */
+public interface NodeWeights {
+
+    double weightOf(int nodeId); // TODO default weight?
+}

--- a/core/src/main/java/org/neo4j/graphalgo/api/RelationshipWeights.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/RelationshipWeights.java
@@ -3,7 +3,7 @@ package org.neo4j.graphalgo.api;
 /**
  * @author mknblch
  */
-public interface Weights {
+public interface RelationshipWeights {
 
     double weightOf(int sourceNodeId, int targetNodeId); // TODO default weight?
 }

--- a/core/src/main/java/org/neo4j/graphalgo/api/WeightMapping.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/WeightMapping.java
@@ -1,5 +1,7 @@
 package org.neo4j.graphalgo.api;
 
+import org.neo4j.graphalgo.core.utils.RawValues;
+
 /**
  * @author mknobloch
  */
@@ -7,12 +9,33 @@ package org.neo4j.graphalgo.api;
 public interface WeightMapping {
 
     /**
-     * returns the weight for ID if set or the default weight otherwise
+     * returns the weight for ID if set or the load-time specified default weight otherwise
      */
     double get(long id);
+
+    /**
+     * returns the weight for ID if set or the given default weight otherwise
+     */
+    double get(long id, double defaultValue);
+
+    default double get(int source, int target) {
+        return get(RawValues.combineIntInt(source, target));
+    }
+
+    default double get(int id) {
+        return get(RawValues.combineIntInt(id, -1));
+    }
+
+    default double get(int id, double defaultValue) {
+        return get(RawValues.combineIntInt(id, -1));
+    }
 
     /**
      * set the weight for ID
      */
     void set(long id, Object weight); // TODO rm?
+
+    default void set(int id, Object weight) {
+        set(RawValues.combineIntInt(id, -1), weight);
+    }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
@@ -35,10 +35,12 @@ public class GraphLoader {
     private String label = null;
     private String relation = null;
     private String relWeightProp = null;
+    private String nodeWeightProp = null;
 
     private final GraphDatabaseAPI api;
     private ExecutorService executorService;
     private double relWeightDefault = 0.0;
+    private double nodeWeightDefault = 0.0;
 
     /**
      * Creates a new serial GraphLoader.
@@ -198,6 +200,34 @@ public class GraphLoader {
     }
 
     /**
+     * Instructs the loader to load node weights by reading the given property.
+     * If the property is not set, the propertyDefaultValue is used instead.
+     *
+     * @param property May not be null; to remove a weight property, use {@link #withoutNodeWeights()} instead.
+     * @param propertyDefaultValue the default value to use if property is not set
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withNodeWeightsFromProperty(String property, double propertyDefaultValue) {
+        this.nodeWeightProp = Objects.requireNonNull(property);
+        this.nodeWeightDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
+     * Instructs the loader to load node weights by reading the given property.
+     * If the property is not set at the relationship, the propertyDefaultValue is used instead.
+     *
+     * @param property May be null
+     * @param propertyDefaultValue the default value to use if property is not set
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withOptionalNodeWeightsFromProperty(String property, double propertyDefaultValue) {
+        this.nodeWeightProp = property;
+        this.nodeWeightDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
      * Instructs the loader to not load any relationship weights. Instead each weight is set
      * to propertyDefaultValue.
      *
@@ -211,6 +241,19 @@ public class GraphLoader {
     }
 
     /**
+     * Instructs the loader to not load any node weights. Instead each weight is set
+     * to propertyDefaultValue.
+     *
+     * @param propertyDefaultValue the default value.
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withDefaultNodeWeight(double propertyDefaultValue) {
+        this.nodeWeightProp = null;
+        this.nodeWeightDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
      * Instructs the loader to not load any weights. The behavior of using weighted graph-functions
      * on a graph without weights is not specified.
      *
@@ -219,6 +262,17 @@ public class GraphLoader {
     public GraphLoader withoutRelationshipWeights() {
         this.relWeightProp = null;
         this.relWeightDefault = 0.0;
+        return this;
+    }
+
+    /**
+     * Instructs the loader to not load any node weights.
+     *
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withoutNodeWeights() {
+        this.nodeWeightProp = null;
+        this.nodeWeightDefault = 0.0;
         return this;
     }
 
@@ -252,6 +306,8 @@ public class GraphLoader {
                 relation,
                 relWeightProp,
                 relWeightDefault,
+                nodeWeightProp,
+                nodeWeightDefault,
                 executorService);
 
         try {

--- a/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
@@ -34,11 +34,11 @@ public class GraphLoader {
 
     private String label = null;
     private String relation = null;
-    private String property = null;
+    private String relWeightProp = null;
 
     private final GraphDatabaseAPI api;
     private ExecutorService executorService;
-    private double propertyDefaultValue = 0.0;
+    private double relWeightDefault = 0.0;
 
     /**
      * Creates a new serial GraphLoader.
@@ -170,43 +170,43 @@ public class GraphLoader {
     }
 
     /**
-     * Instructs the loader to load weights by reading the given property.
+     * Instructs the loader to load relationship weights by reading the given property.
      * If the property is not set, the propertyDefaultValue is used instead.
      *
-     * @param property May not be null; to remove a weight property, use {@link #withoutWeights()} instead.
+     * @param property May not be null; to remove a weight property, use {@link #withoutRelationshipWeights()} instead.
      * @param propertyDefaultValue the default value to use if property is not set
      * @return itself to enable fluent interface
      */
-    public GraphLoader withWeightsFromProperty(String property, double propertyDefaultValue) {
-        this.property = Objects.requireNonNull(property);
-        this.propertyDefaultValue = propertyDefaultValue;
+    public GraphLoader withRelationshipWeightsFromProperty(String property, double propertyDefaultValue) {
+        this.relWeightProp = Objects.requireNonNull(property);
+        this.relWeightDefault = propertyDefaultValue;
         return this;
     }
 
     /**
-     * Instructs the loader to load weights by reading the given property.
+     * Instructs the loader to load relationship weights by reading the given property.
      * If the property is not set at the relationship, the propertyDefaultValue is used instead.
      *
      * @param property May be null
      * @param propertyDefaultValue the default value to use if property is not set
      * @return itself to enable fluent interface
      */
-    public GraphLoader withOptionalWeightsFromProperty(String property, double propertyDefaultValue) {
-        this.property = property;
-        this.propertyDefaultValue = propertyDefaultValue;
+    public GraphLoader withOptionalRelationshipWeightsFromProperty(String property, double propertyDefaultValue) {
+        this.relWeightProp = property;
+        this.relWeightDefault = propertyDefaultValue;
         return this;
     }
 
     /**
-     * Instructs the loader to not load any weights. Instead each weight is set
+     * Instructs the loader to not load any relationship weights. Instead each weight is set
      * to propertyDefaultValue.
      *
      * @param propertyDefaultValue the default value.
      * @return itself to enable fluent interface
      */
-    public GraphLoader withDefaultWeight(double propertyDefaultValue) {
-        this.property = null;
-        this.propertyDefaultValue = propertyDefaultValue;
+    public GraphLoader withDefaultRelationshipWeight(double propertyDefaultValue) {
+        this.relWeightProp = null;
+        this.relWeightDefault = propertyDefaultValue;
         return this;
     }
 
@@ -216,9 +216,9 @@ public class GraphLoader {
      *
      * @return itself to enable fluent interface
      */
-    public GraphLoader withoutWeights() {
-        this.property = null;
-        this.propertyDefaultValue = 0.0;
+    public GraphLoader withoutRelationshipWeights() {
+        this.relWeightProp = null;
+        this.relWeightDefault = 0.0;
         return this;
     }
 
@@ -250,8 +250,8 @@ public class GraphLoader {
                 label,
                 null,
                 relation,
-                property,
-                propertyDefaultValue,
+                relWeightProp,
+                relWeightDefault,
                 executorService);
 
         try {

--- a/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/GraphLoader.java
@@ -36,11 +36,13 @@ public class GraphLoader {
     private String relation = null;
     private String relWeightProp = null;
     private String nodeWeightProp = null;
+    private String nodeProp = null;
 
     private final GraphDatabaseAPI api;
     private ExecutorService executorService;
     private double relWeightDefault = 0.0;
     private double nodeWeightDefault = 0.0;
+    private double nodePropDefault = 0.0;
 
     /**
      * Creates a new serial GraphLoader.
@@ -228,6 +230,34 @@ public class GraphLoader {
     }
 
     /**
+     * Instructs the loader to load node values by reading the given property.
+     * If the property is not set, the propertyDefaultValue is used instead.
+     *
+     * @param property May not be null; to remove a node property, use {@link #withoutNodeProperties()} instead.
+     * @param propertyDefaultValue the default value to use if property is not set
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withNodeProperty(String property, double propertyDefaultValue) {
+        this.nodeProp = Objects.requireNonNull(property);
+        this.nodePropDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
+     * Instructs the loader to load node values by reading the given property.
+     * If the property is not set at the relationship, the propertyDefaultValue is used instead.
+     *
+     * @param property May be null
+     * @param propertyDefaultValue the default value to use if property is not set
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withOptionalNodeProperty(String property, double propertyDefaultValue) {
+        this.nodeProp = property;
+        this.nodePropDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
      * Instructs the loader to not load any relationship weights. Instead each weight is set
      * to propertyDefaultValue.
      *
@@ -254,6 +284,19 @@ public class GraphLoader {
     }
 
     /**
+     * Instructs the loader to not load any node properties. Instead each weight is set
+     * to propertyDefaultValue.
+     *
+     * @param propertyDefaultValue the default value.
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withDefaultNodeProperties(double propertyDefaultValue) {
+        this.nodeProp = null;
+        this.nodePropDefault = propertyDefaultValue;
+        return this;
+    }
+
+    /**
      * Instructs the loader to not load any weights. The behavior of using weighted graph-functions
      * on a graph without weights is not specified.
      *
@@ -273,6 +316,17 @@ public class GraphLoader {
     public GraphLoader withoutNodeWeights() {
         this.nodeWeightProp = null;
         this.nodeWeightDefault = 0.0;
+        return this;
+    }
+
+    /**
+     * Instructs the loader to not load any node properties.
+     *
+     * @return itself to enable fluent interface
+     */
+    public GraphLoader withoutNodeProperties() {
+        this.nodeProp = null;
+        this.nodePropDefault = 0.0;
         return this;
     }
 
@@ -308,6 +362,8 @@ public class GraphLoader {
                 relWeightDefault,
                 nodeWeightProp,
                 nodeWeightDefault,
+                nodeProp,
+                nodePropDefault,
                 executorService);
 
         try {

--- a/core/src/main/java/org/neo4j/graphalgo/core/NullWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/NullWeightMap.java
@@ -19,6 +19,26 @@ public class NullWeightMap implements WeightMapping {
     }
 
     @Override
+    public double get(final long id, final double defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
+    public double get(final int source, final int target) {
+        return defaultValue;
+    }
+
+    @Override
+    public double get(final int id) {
+        return defaultValue;
+    }
+
+    @Override
+    public double get(final int id, final double defaultValue) {
+        return defaultValue;
+    }
+
+    @Override
     public void set(long id, Object weight) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
@@ -34,6 +34,11 @@ public final class WeightMap implements WeightMapping {
     }
 
     @Override
+    public double get(final long id, final double defaultValue) {
+        return weights.getOrDefault(id, defaultValue);
+    }
+
+    @Override
     public void set(long id, Object value) {
         final double doubleVal = extractValue(value);
         if (doubleVal == defaultValue) {

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
@@ -20,19 +20,25 @@ import java.util.function.IntConsumer;
  *
  * @author mknblch
  */
-public class HeavyGraph implements Graph {
+public class HeavyGraph implements Graph, RelationshipWeights, NodeWeights, NodeProperties {
 
     private final IdMap nodeIdMap;
     private final AdjacencyMatrix container;
-    private final WeightMapping weights;
+    private final WeightMapping relationshipWeights;
+    private final WeightMapping nodeWeights;
+    private final WeightMapping nodeProperties;
 
     HeavyGraph(
             IdMap nodeIdMap,
             AdjacencyMatrix container,
-            final WeightMapping weights) {
+            final WeightMapping relationshipWeights,
+            final WeightMapping nodeWeights,
+            final WeightMapping nodeProperties) {
         this.nodeIdMap = nodeIdMap;
         this.container = container;
-        this.weights = weights;
+        this.relationshipWeights = relationshipWeights;
+        this.nodeWeights = nodeWeights;
+        this.nodeProperties = nodeProperties;
     }
 
     @Override
@@ -65,7 +71,7 @@ public class HeavyGraph implements Graph {
             final int nodeId,
             final Direction direction,
             final WeightedRelationshipConsumer consumer) {
-        container.forEach(nodeId, direction, weights, consumer);
+        container.forEach(nodeId, direction, relationshipWeights, consumer);
     }
 
     @Override
@@ -76,7 +82,8 @@ public class HeavyGraph implements Graph {
     @Override
     public Iterator<WeightedRelationshipCursor> weightedRelationshipIterator(
             final int nodeId, final Direction direction) {
-        return container.weightedRelationIterator(nodeId, weights, direction);
+        return container.weightedRelationIterator(nodeId,
+                relationshipWeights, direction);
     }
 
     @Override
@@ -87,5 +94,20 @@ public class HeavyGraph implements Graph {
     @Override
     public long toOriginalNodeId(int mappedNodeId) {
         return nodeIdMap.unmap(mappedNodeId);
+    }
+
+    @Override
+    public double weightOf(final int sourceNodeId, final int targetNodeId) {
+        return relationshipWeights.get(sourceNodeId, targetNodeId);
+    }
+
+    @Override
+    public double weightOf(final int nodeId) {
+        return nodeWeights.get(nodeId);
+    }
+
+    @Override
+    public double valueOf(final int nodeId, final double defaultValue) {
+        return nodeProperties.get(nodeId, defaultValue);
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/leightweight/LightGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/leightweight/LightGraph.java
@@ -214,7 +214,7 @@ public class LightGraph implements Graph {
             int offset = cursor.offset;
             final int limit = cursor.length + offset;
             while (offset < limit) {
-                consumer.accept(node, array[offset], relMap.get(offset), weightMap.get(offset++));
+                consumer.accept(node, array[offset], relMap.get(offset), weightMap.get((long) offset++));
             }
         }
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/leightweight/LightGraphFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/leightweight/LightGraphFactory.java
@@ -48,9 +48,9 @@ public final class LightGraphFactory extends GraphFactory {
                     relationId = new int[]{relId};
                 }
             }
-            weightId = setup.loadAnyProperty()
+            weightId = setup.loadDefaultRelationshipWeight()
                     ? StatementConstants.NO_SUCH_PROPERTY_KEY
-                    : readOp.propertyKeyGetForName(setup.propertyName);
+                    : readOp.propertyKeyGetForName(setup.relationWeightPropertyName);
             nodeCount = Math.toIntExact(readOp.countsForNode(labelId));
             relationCount = Math.toIntExact(relationId == null
                     ? readOp.countsForRelationship(labelId, ReadOperations.ANY_RELATIONSHIP_TYPE, ReadOperations.ANY_LABEL)
@@ -69,8 +69,8 @@ public final class LightGraphFactory extends GraphFactory {
                 0.99);
         adjacency = IntArray.newArray(relationCount + nodeCount * 2L);
         weights = weightId == StatementConstants.NO_SUCH_PROPERTY_KEY
-                ? new NullWeightMap(setup.propertyDefaultValue)
-                : new WeightMap(nodeCount, setup.propertyDefaultValue);
+                ? new NullWeightMap(setup.relationDefaultWeight)
+                : new WeightMap(nodeCount, setup.relationDefaultWeight);
 
         // index 0 is the default for non-connected nodes (by omission of entries)
         adjacencyIdx = 1L;

--- a/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
@@ -19,7 +19,7 @@ public final class GraphViewFactory extends GraphFactory {
                 api,
                 setup.startLabel,
                 setup.relationshipType,
-                setup.propertyName,
-                setup.propertyDefaultValue);
+                setup.relationWeightPropertyName,
+                setup.relationDefaultWeight);
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/sources/BufferedWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/sources/BufferedWeightMap.java
@@ -4,7 +4,7 @@ import com.carrotsearch.hppc.LongDoubleMap;
 import com.carrotsearch.hppc.LongDoubleScatterMap;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphalgo.api.IdMapping;
-import org.neo4j.graphalgo.api.Weights;
+import org.neo4j.graphalgo.api.RelationshipWeights;
 import org.neo4j.graphalgo.core.utils.Importer;
 import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.kernel.api.ReadOperations;
@@ -16,7 +16,7 @@ import org.neo4j.storageengine.api.PropertyItem;
 /**
  * @author mknblch
  */
-public class BufferedWeightMap implements Weights {
+public class BufferedWeightMap implements RelationshipWeights {
 
     private final double propertyDefaultWeight;
     private final LongDoubleMap data;

--- a/tests/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFileLoader.java
+++ b/tests/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFileLoader.java
@@ -3,6 +3,7 @@ package org.neo4j.graphalgo.core.heavyweight;
 import org.neo4j.graphalgo.api.Graph;
 import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.IdMap;
+import org.neo4j.graphalgo.core.NullWeightMap;
 import org.neo4j.graphalgo.core.WeightMap;
 import org.neo4j.graphalgo.core.WeightMappingSerialization;
 import org.neo4j.graphalgo.serialize.ByteBufferDataInput;
@@ -99,7 +100,7 @@ public class HeavyGraphFileLoader {
             final WeightMapping weightMapping = WeightMappingSerialization.read(
                     in);
 
-            return new HeavyGraph(idMap, container, weightMapping);
+            return new HeavyGraph(idMap, container, weightMapping, new NullWeightMap(1.0), new NullWeightMap(1.0));
         }
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/SimpleGraphSetup.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/SimpleGraphSetup.java
@@ -70,7 +70,7 @@ public class SimpleGraphSetup {
         final Graph graph = new GraphLoader((GraphDatabaseAPI) db)
                 .withLabel(LABEL)
                 .withRelationshipType(RELATION)
-                .withWeightsFromProperty(PROPERTY, 0.0)
+                .withRelationshipWeightsFromProperty(PROPERTY, 0.0)
                 .load(factory);
         v0 = graph.toMappedNodeId(n0);
         v1 = graph.toMappedNodeId(n1);

--- a/tests/src/test/java/org/neo4j/graphalgo/core/GraphNegativeTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/GraphNegativeTest.java
@@ -85,7 +85,7 @@ public final class GraphNegativeTest extends RandomGraphTestCase {
     public void shouldLoadWeightedRelationshipsNodesForNonExistingStringTypes() {
         final Graph graph = new GraphLoader(RandomGraphTestCase.db)
                 .withRelationshipType("foo")
-                .withWeightsFromProperty("weight", 42.0)
+                .withRelationshipWeightsFromProperty("weight", 42.0)
                 .load(graphImpl);
         testWeightedRelationships(graph);
     }
@@ -94,7 +94,7 @@ public final class GraphNegativeTest extends RandomGraphTestCase {
     public void shouldLoadWeightedRelationshipsNodesForNonExistingTypes() {
         final Graph graph = new GraphLoader(RandomGraphTestCase.db)
                 .withRelationshipType(RelationshipType.withName("foo"))
-                .withWeightsFromProperty("weight", 42.0)
+                .withRelationshipWeightsFromProperty("weight", 42.0)
                 .load(graphImpl);
         testWeightedRelationships(graph);
     }
@@ -102,7 +102,7 @@ public final class GraphNegativeTest extends RandomGraphTestCase {
     @Test
     public void shouldLoadDefaultWeightForNonExistingProperty() {
         final Graph graph = new GraphLoader(RandomGraphTestCase.db)
-                .withWeightsFromProperty("foo", 13.37)
+                .withRelationshipWeightsFromProperty("foo", 13.37)
                 .load(graphImpl);
         graph.forEachNode(node -> graph.forEachRelationship(
                 node,

--- a/tests/src/test/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFactoryTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraphFactoryTest.java
@@ -82,7 +82,7 @@ public class HeavyGraphFactoryTest {
 
         final Graph graph = new GraphLoader((GraphDatabaseAPI) db)
                 .withLabel("Node1")
-                .withoutWeights()
+                .withoutRelationshipWeights()
                 .withAnyRelationshipType()
                 .load(HeavyGraphFactory.class);
 
@@ -93,7 +93,7 @@ public class HeavyGraphFactoryTest {
     public void testAnyRelation() throws Exception {
         final Graph graph = new GraphLoader((GraphDatabaseAPI) db)
                 .withAnyLabel()
-                .withoutWeights()
+                .withoutRelationshipWeights()
                 .withAnyRelationshipType()
                 .load(HeavyGraphFactory.class);
 
@@ -111,7 +111,7 @@ public class HeavyGraphFactoryTest {
     public void testWithRelation() throws Exception {
         final Graph graph = new GraphLoader((GraphDatabaseAPI) db)
                 .withAnyLabel()
-                .withoutWeights()
+                .withoutRelationshipWeights()
                 .withRelationshipType("REL1")
                 .load(HeavyGraphFactory.class);
 
@@ -131,7 +131,7 @@ public class HeavyGraphFactoryTest {
         final Graph graph = new GraphLoader((GraphDatabaseAPI) db)
                 .withAnyLabel()
                 .withAnyRelationshipType()
-                .withWeightsFromProperty("prop1", 0.0)
+                .withRelationshipWeightsFromProperty("prop1", 0.0)
                 .load(HeavyGraphFactory.class);
 
         graph.forEachRelationship(graph.toMappedNodeId(id1), Direction.OUTGOING, weightedRelationConsumer);

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/ShortestPathDijkstraTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/ShortestPathDijkstraTest.java
@@ -123,7 +123,7 @@ public final class ShortestPathDijkstraTest {
         final Graph graph = new GraphLoader(db)
                 .withLabel(label)
                 .withRelationshipType("TYPE1")
-                .withWeightsFromProperty("cost", Double.MAX_VALUE)
+                .withRelationshipWeightsFromProperty("cost", Double.MAX_VALUE)
                 .load(graphImpl);
 
         final long[] path = new ShortestPathDijkstra(graph).compute(
@@ -156,7 +156,7 @@ public final class ShortestPathDijkstraTest {
         final Graph graph = new GraphLoader(db)
                 .withLabel(label)
                 .withRelationshipType("TYPE2")
-                .withWeightsFromProperty("cost", Double.MAX_VALUE)
+                .withRelationshipWeightsFromProperty("cost", Double.MAX_VALUE)
                 .load(graphImpl);
 
         final long[] path = new ShortestPathDijkstra(graph).compute(


### PR DESCRIPTION
This adds the possibility to load weights for nodes, as well as some additional numeric value from an arbitrary property. This is in preparation for Label Propagation, which comes in an additional PR.

Each of the following commits can be reviewed individually to decrease the size of each change.