### PR TITLE
Rename clustering to graph partitioning

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
@@ -22,8 +22,8 @@ import java.util.stream.Stream;
  */
 public class StronglyConnectedComponentsProc {
 
-    public static final String CONFIG_WRITE_PROPERTY = "communityProperty";
-    public static final String CONFIG_CLUSTER = "community";
+    public static final String CONFIG_WRITE_PROPERTY = "partitionProperty";
+    public static final String CONFIG_CLUSTER = "partition";
 
     @Context
     public GraphDatabaseAPI api;

--- a/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
@@ -22,8 +22,8 @@ import java.util.stream.Stream;
  */
 public class StronglyConnectedComponentsProc {
 
-    public static final String CONFIG_WRITE_PROPERTY = "clusterProperty";
-    public static final String CONFIG_CLUSTER = "cluster";
+    public static final String CONFIG_WRITE_PROPERTY = "communityProperty";
+    public static final String CONFIG_CLUSTER = "community";
 
     @Context
     public GraphDatabaseAPI api;

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
@@ -24,8 +24,8 @@ import java.util.stream.Stream;
 public class UnionFindProc {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
+    public static final String CONFIG_CLUSTER_PROPERTY = "partitionProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "partition";
 
     @Context
     public GraphDatabaseAPI api;
@@ -35,7 +35,7 @@ public class UnionFindProc {
 
     @Procedure(value = "algo.unionFind", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{weightProperty:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
+            "{weightProperty:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc.java
@@ -24,8 +24,8 @@ import java.util.stream.Stream;
 public class UnionFindProc {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "clusterProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "cluster";
+    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
 
     @Context
     public GraphDatabaseAPI api;
@@ -35,7 +35,7 @@ public class UnionFindProc {
 
     @Procedure(value = "algo.unionFind", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{weightProperty:'weight', threshold:0.42, defaultValue:1.0, write: true, clusterProperty:'cluster'}) " +
+            "{weightProperty:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc2 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "clusterProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "cluster";
+    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, clusterProperty:'cluster'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc2 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
+    public static final String CONFIG_CLUSTER_PROPERTY = "partitionProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "partition";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc3 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "clusterProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "cluster";
+    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, clusterProperty:'cluster'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc3 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
+    public static final String CONFIG_CLUSTER_PROPERTY = "partitionProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "partition";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc4 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
+    public static final String CONFIG_CLUSTER_PROPERTY = "partitionProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "partition";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 public class UnionFindProc4 {
 
     public static final String CONFIG_THRESHOLD = "threshold";
-    public static final String CONFIG_CLUSTER_PROPERTY = "clusterProperty";
-    public static final String DEFAULT_CLUSTER_PROPERTY = "cluster";
+    public static final String CONFIG_CLUSTER_PROPERTY = "communityProperty";
+    public static final String DEFAULT_CLUSTER_PROPERTY = "community";
 
     @Context
     public GraphDatabaseAPI api;
@@ -38,7 +38,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, clusterProperty:'cluster'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, communityProperty:'community'}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/results/SCCStreamResult.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/results/SCCStreamResult.java
@@ -14,10 +14,10 @@ public class SCCStreamResult {
      * the set id of the stronly connected component or
      * -1 of not part of a SCC
      */
-    public final long cluster;
+    public final long partition;
 
     public SCCStreamResult(long nodeId, int clusterId) {
         this.nodeId = nodeId;
-        this.cluster = clusterId;
+        this.partition = clusterId;
     }
 }

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -190,7 +190,7 @@ https://en.wikipedia.org/wiki/Connected_component_(graph_theory)
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/79
 
-_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows graph partitioning of the graph based on Relationships and Properties.
+_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows partitioning of the graph based on Relationships and Properties.
 
 ## Progress
 

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -1,14 +1,21 @@
 = Connected Components
 
-_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. In graph theory, a connected component of an undirected graph is a subgraph in which any two vertices are connected to each other by paths, and which is connected to no additional vertices in the graph.
+_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. 
+In graph theory, a connected component of an undirected graph is a subgraph in which any two vertices are connected to each other by paths, and which is connected to no additional vertices in the graph.
 
 == History, Explanation
 
-The _Connected Components_ of a graph represent, in general terms, the pieces of the graph. Two vertices are in the same component of graph if and only if there is some path between them.
+The _Connected Components_ of a graph represent, in general terms, the pieces of the graph. 
+Two vertices are in the same component of graph if and only if there is some path between them.
 
-Finding connected components is at the heart of many graph applications. For example, consider the problem of identifying communities in a set of items. We can represent each item by a node and add an edge between each pair of items that are deemed similar. The connected components of this graph correspond to different classes of items.
+Finding connected components is at the heart of many graph applications. 
+For example, consider the problem of identifying partitions in a set of items. 
+We can represent each item by a node and add an edge between each pair of items that are deemed similar. 
+The connected components of this graph correspond to different classes of items.
 
-Testing whether a graph is connected is an essential preprocessing step for every graph algorithm. Such tests can be performed so quickly and easily that you should always verify that your input graph is connected, even when you know it has to be. Subtle, difficult-to-detect bugs often result when your algorithm is run only on one component of a disconnected graph.
+Testing whether a graph is connected is an essential preprocessing step for every graph algorithm. 
+Such tests can be performed so quickly and easily that you should always verify that your input graph is connected, even when you know it has to be. 
+Subtle, difficult-to-detect bugs often result when your algorithm is run only on one component of a disconnected graph.
 
 == When to use it / use-cases
 
@@ -17,8 +24,12 @@ Testing whether a graph is connected is an essential preprocessing step for ever
 == Algorithm explanation on simple sample graph
 
 Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph
-between those vertices. A connected component of an undirected graph is a maximal connected
-subgraph of the graph. That means that the direction of the relationships  in our graph have no influence as we treat our graph as undirected. We have two implementations of connected components algorithm. First implementations treats the graph as unweighted and the second version is weighted, where you can define the threshold of the weight above which relationships are created. 
+between those vertices. 
+A connected component of an undirected graph is a maximal connected
+subgraph of the graph. 
+That means that the direction of the relationships  in our graph have no influence as we treat our graph as undirected. 
+We have two implementations of connected components algorithm. 
+First implementations treats the graph as unweighted and the second version is weighted, where you can define the threshold of the weight above which relationships are created. 
 
 image::{img}/connected_components.png[]
 
@@ -49,13 +60,13 @@ YIELD nodeId,setId
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.unionFind('User', 'FRIEND', {write:true, communityProperty:"community"}) 
+CALL algo.unionFind('User', 'FRIEND', {write:true, partitionProperty:"partition"}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 ----
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | community
+| name | partition
 | Alice | 0
 | Charles | 0
 | Bridget | 0
@@ -68,15 +79,15 @@ Results show us, that we have two distinct group of users that have no link betw
 
 
 
-.We can also easily check the number and size of communities using cypher.
+.We can also easily check the number and size of partitions using cypher.
 [source,cypher]
 ----
 MATCH (u:User)
-RETURN distinct(u.community) as community,count(*) as size_of_community ORDER by size_of_community DESC 
+RETURN distinct(u.partition) as partition,count(*) as size_of_partition ORDER by size_of_partition DESC 
 ----
 === Weighted version:
 
-If you define the property that holds the weight(weightProperty) and the threshold,it means the nodes are only connected if the threshold on the weight of the relationship is high enough otherwise the relationship is thrown away.
+If you define the property that holds the weight(weightProperty) and the threshold,it means the nodes are only connected, if the threshold on the weight of the relationship is high enough otherwise the relationship is thrown away.
 
 .Running algorithm and streaming results
 [source,cypher]
@@ -87,14 +98,14 @@ YIELD nodeId,setId
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.unionFind('User', 'FRIEND', {write:true, communityProperty:"community",weightProperty:'weight', defaultValue:0.0, threshold:1.0}) 
+CALL algo.unionFind('User', 'FRIEND', {write:true, partitionProperty:"partition",weightProperty:'weight', defaultValue:0.0, threshold:1.0}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 ----
 
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | community
+| name | partition
 | Alice | 0
 | Charles | 0
 | Bridget | 1
@@ -113,9 +124,9 @@ We can observe, that because the weight of the relationship betwen Bridget and A
 [source,cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-defaultValue:1.0, write: true, communityProperty:'community',weightProperty:'weight'}) 
+defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight'}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
-- finds connected communities and potentially writes back to the node as a property community. 
+- finds connected partitions and potentially writes back to the node as a property partition. 
 
 ----
 
@@ -127,7 +138,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | weightProperty | string | null | yes | property name that contains weight, if null treats the graph as unweighted. Must be numeric.
 | write | boolean | true | yes | if result should be written back as node property
-| communityProperty | string | 'community' | yes | property name written back the id of the community particular node belongs to
+| partitionProperty | string | 'partition' | yes | property name written back the id of the partition particular node belongs to
 | threshold | float | null | yes | value of the weight above which the relationship is not thrown away
 | defaultValue | float | null | yes | default value of the weight in case it is missing or invalid
 |===
@@ -137,7 +148,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 |===
 | name | type | description
 | nodes | int | number of nodes considered
-| setCount | int | number of communities found
+| setCount | int | number of partitions found
 | loadMillis | int | milliseconds for loading data
 | computeMillis | int | milliseconds for running the algorithm
 | writeMillis | int | milliseconds for writing result data back
@@ -167,7 +178,7 @@ YIELD nodeId, setId - yields a setId to each node id
 |===
 | name | type | description
 | nodeId | int | node id
-| setId | int | community id
+| setId | int | partition id
 |===
 
 == References
@@ -181,7 +192,7 @@ https://en.wikipedia.org/wiki/Connected_component_(graph_theory)
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/79
 
-_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows community detection of the graph based on Relationships and Properties.
+_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows graph partitioning of the graph based on Relationships and Properties.
 
 ## Progress
 

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -6,7 +6,7 @@ _Connected Components_ or _UnionFind_ basically finds sets of connected nodes wh
 
 The _Connected Components_ of a graph represent, in general terms, the pieces of the graph. Two vertices are in the same component of graph if and only if there is some path between them.
 
-Finding connected components is at the heart of many graph applications. For example, consider the problem of identifying clusters in a set of items. We can represent each item by a node and add an edge between each pair of items that are deemed similar. The connected components of this graph correspond to different classes of items.
+Finding connected components is at the heart of many graph applications. For example, consider the problem of identifying communities in a set of items. We can represent each item by a node and add an edge between each pair of items that are deemed similar. The connected components of this graph correspond to different classes of items.
 
 Testing whether a graph is connected is an essential preprocessing step for every graph algorithm. Such tests can be performed so quickly and easily that you should always verify that your input graph is connected, even when you know it has to be. Subtle, difficult-to-detect bugs often result when your algorithm is run only on one component of a disconnected graph.
 
@@ -49,13 +49,13 @@ YIELD nodeId,setId
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.unionFind('User', 'FRIEND', {write:true, clusterProperty:"cluster"}) 
+CALL algo.unionFind('User', 'FRIEND', {write:true, communityProperty:"community"}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 ----
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | setId
+| name | community
 | Alice | 0
 | Charles | 0
 | Bridget | 0
@@ -68,11 +68,11 @@ Results show us, that we have two distinct group of users that have no link betw
 
 
 
-.We can also easily check the number and size of clusters using cypher.
+.We can also easily check the number and size of communities using cypher.
 [source,cypher]
 ----
 MATCH (u:User)
-RETURN distinct(u.cluster) as cluster,count(*) as size_of_cluster ORDER by size_of_cluster DESC 
+RETURN distinct(u.community) as community,count(*) as size_of_community ORDER by size_of_community DESC 
 ----
 === Weighted version:
 
@@ -87,14 +87,14 @@ YIELD nodeId,setId
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.unionFind('User', 'FRIEND', {write:true, clusterProperty:"cluster",weightProperty:'weight', defaultValue:0.0, threshold:1.0}) 
+CALL algo.unionFind('User', 'FRIEND', {write:true, communityProperty:"community",weightProperty:'weight', defaultValue:0.0, threshold:1.0}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 ----
 
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | setId
+| name | community
 | Alice | 0
 | Charles | 0
 | Bridget | 1
@@ -113,9 +113,9 @@ We can observe, that because the weight of the relationship betwen Bridget and A
 [source,cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-defaultValue:1.0, write: true, clusterProperty:'cluster',weightProperty:'weight'}) 
+defaultValue:1.0, write: true, communityProperty:'community',weightProperty:'weight'}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
-- finds connected clusters and potentially writes back to the node as a property cluster. 
+- finds connected communities and potentially writes back to the node as a property community. 
 
 ----
 
@@ -127,7 +127,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | weightProperty | string | null | yes | property name that contains weight, if null treats the graph as unweighted. Must be numeric.
 | write | boolean | true | yes | if result should be written back as node property
-| clusterProperty | string | 'cluster' | yes | property name written back the id of the cluster particular node belongs to
+| communityProperty | string | 'community' | yes | property name written back the id of the community particular node belongs to
 | threshold | float | null | yes | value of the weight above which the relationship is not thrown away
 | defaultValue | float | null | yes | default value of the weight in case it is missing or invalid
 |===
@@ -137,7 +137,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 |===
 | name | type | description
 | nodes | int | number of nodes considered
-| setCount | int | number of clusters found
+| setCount | int | number of communities found
 | loadMillis | int | milliseconds for loading data
 | computeMillis | int | milliseconds for running the algorithm
 | writeMillis | int | milliseconds for writing result data back
@@ -167,7 +167,7 @@ YIELD nodeId, setId - yields a setId to each node id
 |===
 | name | type | description
 | nodeId | int | node id
-| setId | int | cluster id
+| setId | int | community id
 |===
 
 == References
@@ -181,7 +181,7 @@ https://en.wikipedia.org/wiki/Connected_component_(graph_theory)
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/79
 
-_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows clustering the graph based on Relationships and Properties.
+_Connected Components_ or _UnionFind_ basically finds sets of connected nodes where each node is reachable from any other node in the same set. One implementation also evaluates a Predicate on each relation which allows community detection of the graph based on Relationships and Properties.
 
 ## Progress
 

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -23,11 +23,9 @@ Subtle, difficult-to-detect bugs often result when your algorithm is run only on
 
 == Algorithm explanation on simple sample graph
 
-Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph
-between those vertices. 
-A connected component of an undirected graph is a maximal connected
-subgraph of the graph. 
-That means that the direction of the relationships  in our graph have no influence as we treat our graph as undirected. 
+Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph between those vertices. 
+A connected component of an undirected graph is a maximal connected subgraph of the graph. 
+That means that the direction of the relationships in our graph have no influence as we treat our graph as undirected. 
 We have two implementations of connected components algorithm. 
 First implementations treats the graph as unweighted and the second version is weighted, where you can define the threshold of the weight above which relationships are created. 
 

--- a/doc/label-propagation.adoc
+++ b/doc/label-propagation.adoc
@@ -1,10 +1,16 @@
-= Community Detection: Label Propagation
+= Graph Partitioning: Label Propagation
 
-_Label Propagation_ algorithm (LPA) is an extremely fast community detection method and is widely used in large scale networks. Community detection and analysis is an important methodology for understanding the organization of various real-world networks and has applications in problems as diverse as consensus formation in social communities or the identification of functional modules in biochemical networks. 
+_Label Propagation_ algorithm (LPA) is an extremely fast graph partitioning method and is widely used in large scale networks. 
+Graph partitioning ( community detection ) is an important methodology for understanding the organization of various real-world networks and has applications in problems as diverse as consensus formation in social communities or the identification of functional modules in biochemical networks. 
 
 == History, Explanation
 
-Community structure is considered one of the most interesting features in complex networks. Many real-world complex systems exhibit community structure, where individuals with similar properties form a community. The identification of communities in a network is important for understanding the structure of said network, in a specific perspective. Thus, community detection in complex networks gained immense interest over the last decade. A lot of community detection methods were proposed, and one of them is the label propagation algorithm (LPA). The simplicity and time efficiency of the LPA make it a popular community detection method. 
+Community structure is considered one of the most interesting features in complex networks. 
+Many real-world complex systems exhibit community structure, where individuals with similar properties form a partition (community). 
+The identification of partitions in a network is important for understanding the structure of said network, in a specific perspective. 
+Thus, graph partitioning in complex networks gained immense interest over the last decade. 
+A lot of graph partitioning methods were proposed, and one of them is the label propagation algorithm (LPA).
+The simplicity and time efficiency of the LPA make it a popular graph partitioning method. 
 
 
 == When to use it / use-cases
@@ -69,7 +75,7 @@ partitionProperty - simple label propagation kernel
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/95
 
-_Label Propagation_ is a community detection algorithm already implemented in current apoc-procedures. 
+_Label Propagation_ is a graph partitioning algorithm already implemented in current apoc-procedures. 
 
 ## Progress
 

--- a/doc/label-propagation.adoc
+++ b/doc/label-propagation.adoc
@@ -1,4 +1,4 @@
-= Clustering: Label Propagation
+= Community Detection: Label Propagation
 
 _Label Propagation_ algorithm (LPA) is an extremely fast community detection method and is widely used in large scale networks. Community detection and analysis is an important methodology for understanding the organization of various real-world networks and has applications in problems as diverse as consensus formation in social communities or the identification of functional modules in biochemical networks. 
 
@@ -69,7 +69,7 @@ partitionProperty - simple label propagation kernel
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/95
 
-_Label Propagation_ is a clustering algorithm already implemented in current apoc-procedures. 
+_Label Propagation_ is a community detection algorithm already implemented in current apoc-procedures. 
 
 ## Progress
 

--- a/doc/louvain.adoc
+++ b/doc/louvain.adoc
@@ -1,6 +1,6 @@
-= Community Detection: Louvain
+= Graph Partitioning: Louvain
 
-_Louvain_ is an algorithm for detecting communities in networks that relies upon a heuristic for maximizing the modularity. 
+_Louvain_ is an algorithm for detecting graph partitions in networks that relies upon a heuristic for maximizing the modularity. 
 
 == History, Explanation
 
@@ -23,7 +23,7 @@ _Louvain_ is an algorithm for detecting communities in networks that relies upon
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/96
 
-_Louvain_ is an algorithm for detecting communities in networks that relies upon a heuristic for maximizing the modularity. 
+_Louvain_ is an algorithm for detecting graph partitions in networks that relies upon a heuristic for maximizing the modularity. 
 
 - [ ] single threaded implementation
 - [ ] tests

--- a/doc/louvain.adoc
+++ b/doc/louvain.adoc
@@ -1,4 +1,4 @@
-= Clustering: Louvain
+= Community Detection: Louvain
 
 _Louvain_ is an algorithm for detecting communities in networks that relies upon a heuristic for maximizing the modularity. 
 

--- a/doc/strongly-connected-components.adoc
+++ b/doc/strongly-connected-components.adoc
@@ -40,14 +40,14 @@ CREATE (nAlice)-[:FOLLOW]->(nBridget)
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc('User','FOLLOW', {write:true,clusterProperty:'cluster'})
+CALL algo.scc('User','FOLLOW', {write:true,communityProperty:'community'})
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 ----
 
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | cluster
+| name | community
 | Alice | 1
 | Bridget | 1
 | Michael | 1
@@ -58,11 +58,11 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
 We can see that we have 2 strongly connected components in our sample graph. The first and biggest component has members Alice,Bridget,Michael and the second compomenet has Doug and Mark. 
 
-.Find the largest cluster
+.Find the largest community
 [source,cypher]
 ----
 MATCH (u:User)
-RETURN distinct(u.cluster) as cluster,count(*) as size_of_cluster ORDER by size_of_cluster DESC LIMIT 1
+RETURN distinct(u.community) as community,count(*) as size_of_community ORDER by size_of_community DESC LIMIT 1
 ----
 == Example Usage
 
@@ -71,10 +71,10 @@ RETURN distinct(u.cluster) as cluster,count(*) as size_of_cluster ORDER by size_
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc(label:String, relationship:String, {write:true,clusterProperty:'cluster'}) 
+CALL algo.scc(label:String, relationship:String, {write:true,communityProperty:'community'}) 
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
-- finds strongly connected clusters and potentially writes back to the node as a property cluster. 
+- finds strongly connected communities and potentially writes back to the node as a property community. 
 ----
 
 .Parameters
@@ -84,7 +84,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | write | boolean | true | yes | if result should be written back as node property
-| clusterProperty | string | 'cluster' | yes | property name written back to
+| communityProperty | string | 'community' | yes | property name written back to
 
 |===
 
@@ -92,9 +92,9 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 [opts="header",cols="1,1,6"]
 |===
 | name | type | description
-| setCount | int | number of clusters found
-| maxSetSize | int | number of members in biggest cluster
-| minSetSize | int | number of members in smallest cluster
+| setCount | int | number of communities found
+| maxSetSize | int | number of members in biggest community
+| minSetSize | int | number of members in smallest community
 | loadMillis | int | milliseconds for loading data
 | computeMillis | int | milliseconds for running the algorithm
 | writeMillis | int | milliseconds for writing result data back

--- a/doc/strongly-connected-components.adoc
+++ b/doc/strongly-connected-components.adoc
@@ -1,10 +1,14 @@
 = Strongly Connected Components
 
-_SCC_ is a class algorithms for finding groups of nodes where each node is directly reachable from every other node in the group. The strongly connected components  of an arbitrary directed graph form a partition into subgraphs that are themselves strongly connected.There are several algorithms to compute the SCC.
+_SCC_ is a class algorithms for finding groups of nodes where each node is directly reachable from every other node in the group. 
+The strongly connected components  of an arbitrary directed graph form a partition into subgraphs that are themselves strongly connected.There are several algorithms to compute the SCC.
 
 == History, Explanation
 
-Decomposing a directed graph into its strongly connected components is a classic application of depth-first search. The problem of finding connected components is at the heart of many graph application. Generally speaking, the connected components of the graph correspond to different classes of objects. The first linear-time algorithm for strongly connected components is due to Tarjan (1972).
+Decomposing a directed graph into its strongly connected components is a classic application of depth-first search. 
+The problem of finding connected components is at the heart of many graph application. 
+Generally speaking, the connected components of the graph correspond to different classes of objects. 
+The first linear-time algorithm for strongly connected components is due to Tarjan (1972).
 
 == When to use it / use-cases
 
@@ -14,7 +18,8 @@ Decomposing a directed graph into its strongly connected components is a classic
 
 image::{img}/strongly_connected_components.png[]
 
-A directed graph is strongly connected if there is a path between all pairs of vertices. This algorithms treats the graph as directed, so the direction of the relationship is important and strongly connected compoment exists only if there are relationships between nodes in both direction. 
+A directed graph is strongly connected if there is a path between all pairs of vertices. 
+This algorithms treats the graph as directed, so the direction of the relationship is important and strongly connected compoment exists only if there are relationships between nodes in both direction. 
 
 .Create sample graph
 [source,cypher]
@@ -40,14 +45,14 @@ CREATE (nAlice)-[:FOLLOW]->(nBridget)
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc('User','FOLLOW', {write:true,communityProperty:'community'})
+CALL algo.scc('User','FOLLOW', {write:true,partitionProperty:'partition'})
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 ----
 
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | community
+| name | partition
 | Alice | 1
 | Bridget | 1
 | Michael | 1
@@ -58,11 +63,11 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
 We can see that we have 2 strongly connected components in our sample graph. The first and biggest component has members Alice,Bridget,Michael and the second compomenet has Doug and Mark. 
 
-.Find the largest community
+.Find the largest partition
 [source,cypher]
 ----
 MATCH (u:User)
-RETURN distinct(u.community) as community,count(*) as size_of_community ORDER by size_of_community DESC LIMIT 1
+RETURN distinct(u.partition) as partition,count(*) as size_of_partition ORDER by size_of_partition DESC LIMIT 1
 ----
 == Example Usage
 
@@ -71,10 +76,10 @@ RETURN distinct(u.community) as community,count(*) as size_of_community ORDER by
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc(label:String, relationship:String, {write:true,communityProperty:'community'}) 
+CALL algo.scc(label:String, relationship:String, {write:true,partitionProperty:'partition'}) 
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
-- finds strongly connected communities and potentially writes back to the node as a property community. 
+- finds strongly connected partitions and potentially writes back to the node as a property partition. 
 ----
 
 .Parameters
@@ -84,7 +89,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | write | boolean | true | yes | if result should be written back as node property
-| communityProperty | string | 'community' | yes | property name written back to
+| partitionProperty | string | 'partition' | yes | property name written back to
 
 |===
 
@@ -92,9 +97,9 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 [opts="header",cols="1,1,6"]
 |===
 | name | type | description
-| setCount | int | number of communities found
-| maxSetSize | int | number of members in biggest community
-| minSetSize | int | number of members in smallest community
+| setCount | int | number of partitions found
+| maxSetSize | int | number of members in biggest partition
+| minSetSize | int | number of members in smallest partition
 | loadMillis | int | milliseconds for loading data
 | computeMillis | int | milliseconds for running the algorithm
 | writeMillis | int | milliseconds for writing result data back

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/IterativeTarjanSCCTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/IterativeTarjanSCCTest.java
@@ -151,7 +151,7 @@ public class IterativeTarjanSCCTest {
 
         final IntIntScatterMap testMap = new IntIntScatterMap();
 
-        String cypher = "CALL algo.scc.iterative.stream() YIELD nodeId, cluster";
+        String cypher = "CALL algo.scc.iterative.stream() YIELD nodeId, partition";
 
         api.execute(cypher).accept(row -> {
             testMap.addTo(row.getNumber("partition").intValue(), 1);

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/IterativeTarjanSCCTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/IterativeTarjanSCCTest.java
@@ -132,7 +132,7 @@ public class IterativeTarjanSCCTest {
             return true;
         });
 
-        String cypher2 = "MATCH (n) RETURN n.cluster as c";
+        String cypher2 = "MATCH (n) RETURN n.partition as c";
         final IntIntScatterMap testMap = new IntIntScatterMap();
         api.execute(cypher2).accept(row -> {
             testMap.addTo(row.getNumber("c").intValue(), 1);
@@ -154,7 +154,7 @@ public class IterativeTarjanSCCTest {
         String cypher = "CALL algo.scc.iterative.stream() YIELD nodeId, cluster";
 
         api.execute(cypher).accept(row -> {
-            testMap.addTo(row.getNumber("cluster").intValue(), 1);
+            testMap.addTo(row.getNumber("partition").intValue(), 1);
             return true;
         });
 

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/SCCTunedTarjanTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/SCCTunedTarjanTest.java
@@ -155,7 +155,7 @@ public class SCCTunedTarjanTest {
 
         final IntIntScatterMap testMap = new IntIntScatterMap();
 
-        String cypher = "CALL algo.scc.tunedTarjan.stream() YIELD nodeId, cluster";
+        String cypher = "CALL algo.scc.tunedTarjan.stream() YIELD nodeId, partition";
 
         api.execute(cypher).accept(row -> {
             testMap.addTo(row.getNumber("partition").intValue(), 1);

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/SCCTunedTarjanTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/SCCTunedTarjanTest.java
@@ -135,7 +135,7 @@ public class SCCTunedTarjanTest {
             return true;
         });
 
-        String cypher2 = "MATCH (n) RETURN n.cluster as c";
+        String cypher2 = "MATCH (n) RETURN n.partition as c";
         final IntIntScatterMap testMap = new IntIntScatterMap();
         api.execute(cypher2).accept(row -> {
             testMap.addTo(row.getNumber("c").intValue(), 1);
@@ -158,7 +158,7 @@ public class SCCTunedTarjanTest {
         String cypher = "CALL algo.scc.tunedTarjan.stream() YIELD nodeId, cluster";
 
         api.execute(cypher).accept(row -> {
-            testMap.addTo(row.getNumber("cluster").intValue(), 1);
+            testMap.addTo(row.getNumber("partition").intValue(), 1);
             return true;
         });
 


### PR DESCRIPTION
I change the algo.scc and algo.unionFind input parameter `clusterProperty` to `partitionProperty` and changed their default value to `partition`. 

Fixes [#186](https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/186)

I also put each sentence in it's own line for algo.scc and algo.unionFind docs and tried to replace clustering/community detection with graph partitioning wherever I found sense.