### PR TITLE
Docs Concurrency update

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/AllShortestPathsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/AllShortestPathsProc.java
@@ -33,7 +33,7 @@ public class AllShortestPathsProc {
 
     @Procedure("algo.allShortestPaths.stream")
     @Description("CALL algo.allShortestPaths.stream(weightProperty:String" +
-            "{nodeQuery:'labelName', relationshipQuery:'relationshipName', defaultValue:1.0}) " +
+            "{nodeQuery:'labelName', relationshipQuery:'relationshipName', defaultValue:1.0, concurrency:4}) " +
             "YIELD sourceNodeId, targetNodeId, distance - yields a stream of {sourceNodeId, targetNodeId, distance}")
     public Stream<AllShortestPaths.Result> allShortestPathsStream(
             @Name(value = "propertyName") String propertyName,

--- a/algo/src/main/java/org/neo4j/graphalgo/BetweennessCentralityProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/BetweennessCentralityProc.java
@@ -71,7 +71,8 @@ public class BetweennessCentralityProc {
      * Procedure accepts {in, incoming, <, out, outgoing, >, both, <>} as direction
      */
     @Procedure(value = "algo.betweenness.stream")
-    @Description("CALL algo.betweenness.stream(label:String, relationship:String, {direction:'out'}) YIELD nodeId, centrality - yields centrality for each node")
+    @Description("CALL algo.betweenness.stream(label:String, relationship:String, {direction:'out', concurrency :8})" +
+                 "YIELD nodeId, centrality - yields centrality for each node")
     public Stream<BetweennessCentrality.Result> betweennessStream(
             @Name(value = "label", defaultValue = "") String label,
             @Name(value = "relationship", defaultValue = "") String relationship,
@@ -107,7 +108,8 @@ public class BetweennessCentralityProc {
     }
 
     @Procedure(value = "algo.betweenness.exp1", mode = Mode.WRITE)
-    @Description("CALL algo.betweenness.exp1(label:String, relationship:String, {direction:'out', write:true, writeProperty:'centrality', stats:true, scaleFactor:100000}) YIELD " +
+    @Description("CALL algo.betweenness.exp1(label:String, relationship:String, " +
+            "{direction:'out', write:true, writeProperty:'centrality', stats:true, scaleFactor:100000}) YIELD " +
             "loadMillis, computeMillis, writeMillis, nodes, minCentrality, maxCentrality, sumCentrality] - yields status of evaluation")
     public Stream<BetweennessCentralityProcResult> betweennessSucessorBrandes(
             @Name(value = "label", defaultValue = "") String label,
@@ -164,7 +166,7 @@ public class BetweennessCentralityProc {
 
 
     @Procedure(value = "algo.betweenness", mode = Mode.WRITE)
-    @Description("CALL algo.betweenness(label:String, relationship:String, {direction:'out',write:true, writeProperty:'centrality', stats:true}) YIELD " +
+    @Description("CALL algo.betweenness(label:String, relationship:String, {direction:'out',write:true, writeProperty:'centrality', stats:true, concurrency:8}) YIELD " +
             "loadMillis, computeMillis, writeMillis, nodes, minCentrality, maxCentrality, sumCentrality - yields status of evaluation")
     public Stream<BetweennessCentralityProcResult> betweenness(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/BetweennessCentralityProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/BetweennessCentralityProc.java
@@ -71,7 +71,7 @@ public class BetweennessCentralityProc {
      * Procedure accepts {in, incoming, <, out, outgoing, >, both, <>} as direction
      */
     @Procedure(value = "algo.betweenness.stream")
-    @Description("CALL algo.betweenness.stream(label:String, relationship:String, {direction:'out', concurrency :8})" +
+    @Description("CALL algo.betweenness.stream(label:String, relationship:String, {direction:'out', concurrency :4})" +
                  "YIELD nodeId, centrality - yields centrality for each node")
     public Stream<BetweennessCentrality.Result> betweennessStream(
             @Name(value = "label", defaultValue = "") String label,
@@ -166,7 +166,7 @@ public class BetweennessCentralityProc {
 
 
     @Procedure(value = "algo.betweenness", mode = Mode.WRITE)
-    @Description("CALL algo.betweenness(label:String, relationship:String, {direction:'out',write:true, writeProperty:'centrality', stats:true, concurrency:8}) YIELD " +
+    @Description("CALL algo.betweenness(label:String, relationship:String, {direction:'out',write:true, writeProperty:'centrality', stats:true, concurrency:4}) YIELD " +
             "loadMillis, computeMillis, writeMillis, nodes, minCentrality, maxCentrality, sumCentrality - yields status of evaluation")
     public Stream<BetweennessCentralityProcResult> betweenness(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/ClosenessCentralityProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/ClosenessCentralityProc.java
@@ -38,7 +38,7 @@ public class ClosenessCentralityProc {
     public KernelTransaction transaction;
 
     @Procedure(value = "algo.closeness.stream")
-    @Description("CALL algo.closeness.stream(label:String, relationship:String{concurrency:8}) YIELD nodeId, centrality - yields centrality for each node")
+    @Description("CALL algo.closeness.stream(label:String, relationship:String{concurrency:4}) YIELD nodeId, centrality - yields centrality for each node")
     public Stream<MSClosenessCentrality.Result> closenessStream(
             @Name(value = "label", defaultValue = "") String label,
             @Name(value = "relationship", defaultValue = "") String relationship,
@@ -63,7 +63,7 @@ public class ClosenessCentralityProc {
     }
 
     @Procedure(value = "algo.closeness", mode = Mode.WRITE)
-    @Description("CALL algo.closeness(label:String, relationship:String, {write:true, writeProperty:'centrality, concurrency:8'}) YIELD " +
+    @Description("CALL algo.closeness(label:String, relationship:String, {write:true, writeProperty:'centrality, concurrency:4'}) YIELD " +
             "loadMillis, computeMillis, writeMillis, nodes] - yields evaluation details")
     public Stream<ClosenessCentralityProcResult> closeness(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/ClosenessCentralityProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/ClosenessCentralityProc.java
@@ -38,7 +38,7 @@ public class ClosenessCentralityProc {
     public KernelTransaction transaction;
 
     @Procedure(value = "algo.closeness.stream")
-    @Description("CALL algo.closeness.stream(label:String, relationship:String) YIELD nodeId, centrality - yields centrality for each node")
+    @Description("CALL algo.closeness.stream(label:String, relationship:String{concurrency:8}) YIELD nodeId, centrality - yields centrality for each node")
     public Stream<MSClosenessCentrality.Result> closenessStream(
             @Name(value = "label", defaultValue = "") String label,
             @Name(value = "relationship", defaultValue = "") String relationship,
@@ -63,7 +63,7 @@ public class ClosenessCentralityProc {
     }
 
     @Procedure(value = "algo.closeness", mode = Mode.WRITE)
-    @Description("CALL algo.closeness(label:String, relationship:String, {write:true, writeProperty:'centrality'}) YIELD " +
+    @Description("CALL algo.closeness(label:String, relationship:String, {write:true, writeProperty:'centrality, concurrency:8'}) YIELD " +
             "loadMillis, computeMillis, writeMillis, nodes] - yields evaluation details")
     public Stream<ClosenessCentralityProcResult> closeness(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
@@ -50,7 +50,7 @@ public final class LabelPropagationProc {
     @Procedure(name = "algo.labelPropagation", mode = Mode.WRITE)
     @Description("CALL algo.labelPropagation(" +
             "label:String, relationship:String, direction:String, " +
-            "{iterations:1, weightProperty:'weight', partitionProperty:'partition', write:true}) " +
+            "{iterations:1, weightProperty:'weight', partitionProperty:'partition', write:true, concurrency:4}) " +
             "YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, write, weightProperty, partitionProperty - " +
             "simple label propagation kernel")
     public Stream<LabelPropagationStats> labelPropagation(

--- a/algo/src/main/java/org/neo4j/graphalgo/MSColoringProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/MSColoringProc.java
@@ -33,7 +33,7 @@ public class MSColoringProc {
 
     @Procedure(value = "algo.unionFind.mscoloring", mode = Mode.WRITE)
     @Description("CALL algo.unionFind.mscoloring(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition', concurrency:8}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition', concurrency:4}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -69,7 +69,7 @@ public class MSColoringProc {
 
     @Procedure(value = "algo.unionFind.mscoloring.stream")
     @Description("CALL algo.unionFind.mscoloring.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:8) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:4) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<MSColoring.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
@@ -48,7 +48,7 @@ public final class PageRankProc {
 
     @Procedure(value = "algo.pageRank", mode = Mode.WRITE)
     @Description("CALL algo.pageRank(label:String, relationship:String, " +
-            "{iterations:5, dampingFactor:0.85, write: true, writeProperty:'pagerank', concurrency:8}) " +
+            "{iterations:5, dampingFactor:0.85, write: true, writeProperty:'pagerank', concurrency:4}) " +
             "YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, write, writeProperty" +
             " - calculates page rank and potentially writes back")
     public Stream<PageRankScore.Stats> pageRank(
@@ -73,7 +73,7 @@ public final class PageRankProc {
 
     @Procedure(value = "algo.pageRank.stream", mode = Mode.READ)
     @Description("CALL algo.pageRank.stream(label:String, relationship:String, " +
-            "{iterations:20, dampingFactor:0.85, concurrency:8}) " +
+            "{iterations:20, dampingFactor:0.85, concurrency:4}) " +
             "YIELD node, score - calculates page rank and streams results")
     public Stream<PageRankScore> pageRankStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/PageRankProc.java
@@ -48,7 +48,7 @@ public final class PageRankProc {
 
     @Procedure(value = "algo.pageRank", mode = Mode.WRITE)
     @Description("CALL algo.pageRank(label:String, relationship:String, " +
-            "{iterations:5, dampingFactor:0.85, write: true, writeProperty:'pagerank'}) " +
+            "{iterations:5, dampingFactor:0.85, write: true, writeProperty:'pagerank', concurrency:8}) " +
             "YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, write, writeProperty" +
             " - calculates page rank and potentially writes back")
     public Stream<PageRankScore.Stats> pageRank(
@@ -73,7 +73,7 @@ public final class PageRankProc {
 
     @Procedure(value = "algo.pageRank.stream", mode = Mode.READ)
     @Description("CALL algo.pageRank.stream(label:String, relationship:String, " +
-            "{iterations:20, dampingFactor:0.85}) " +
+            "{iterations:20, dampingFactor:0.85, concurrency:8}) " +
             "YIELD node, score - calculates page rank and streams results")
     public Stream<PageRankScore> pageRankStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/ShortestPathDeltaSteppingProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/ShortestPathDeltaSteppingProc.java
@@ -77,7 +77,7 @@ public class ShortestPathDeltaSteppingProc {
                 .withProgressLogger(ProgressLogger.wrap(log, "ShortestPaths(DeltaStepping)"))
                 .withTerminationFlag(TerminationFlag.wrap(transaction))
                 .withExecutorService(Executors.newFixedThreadPool(
-                        configuration.getInt("concurrency", 4)
+                        configuration.getConcurrency()
                 )).compute(startNode.getId());
 
         graph.release();

--- a/algo/src/main/java/org/neo4j/graphalgo/ShortestPathDeltaSteppingProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/ShortestPathDeltaSteppingProc.java
@@ -52,7 +52,7 @@ public class ShortestPathDeltaSteppingProc {
 
     @Procedure("algo.shortestPath.deltaStepping.stream")
     @Description("CALL algo.shortestPath.deltaStepping.stream(startNode:Node, weightProperty:String, delta:Double" +
-            "{label:'labelName', relationship:'relationshipName', defaultValue:1.0}) " +
+            "{label:'labelName', relationship:'relationshipName', defaultValue:1.0, concurrency:4}) " +
             "YIELD nodeId, distance - yields a stream of {nodeId, distance} from start to end (inclusive)")
     public Stream<ShortestPathDeltaStepping.DeltaSteppingResult> deltaSteppingStream(
             @Name("startNode") Node startNode,

--- a/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
@@ -285,7 +285,7 @@ public class StronglyConnectedComponentsProc {
         loadTimer.stop();
 
         final MultistepSCC multistep = new MultistepSCC(graph, org.neo4j.graphalgo.core.utils.Pools.DEFAULT,
-                configuration.getNumber("concurrency", 1).intValue(),
+                configuration.getConcurrency(),
                 configuration.getNumber("cutoff", 100_000).intValue())
                 .withProgressLogger(ProgressLogger.wrap(log, "SCC(MultiStep)"))
                 .withTerminationFlag(TerminationFlag.wrap(transaction));
@@ -330,7 +330,7 @@ public class StronglyConnectedComponentsProc {
                 .load(configuration.getGraphImpl());
 
         final MultistepSCC multistep = new MultistepSCC(graph, org.neo4j.graphalgo.core.utils.Pools.DEFAULT,
-                configuration.getNumber("concurrency", 1).intValue(),
+                configuration.getConcurrency(),
                 configuration.getNumber("cutoff", 100_000).intValue())
                 .withProgressLogger(ProgressLogger.wrap(log, "SCC(MultiStep)"))
                 .withTerminationFlag(TerminationFlag.wrap(transaction));
@@ -360,7 +360,7 @@ public class StronglyConnectedComponentsProc {
                 .load(configuration.getGraphImpl());
 
         final ForwardBackwardScc algo = new ForwardBackwardScc(graph, Pools.DEFAULT,
-                configuration.getConcurrency(1))
+                configuration.getConcurrency())
                 .withProgressLogger(ProgressLogger.wrap(log, "SCC(ForwardBackward)"))
                 .withTerminationFlag(TerminationFlag.wrap(transaction))
                 .compute(graph.toMappedNodeId(startNodeId));

--- a/algo/src/main/java/org/neo4j/graphalgo/TriangleProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/TriangleProc.java
@@ -39,7 +39,7 @@ public class TriangleProc {
     public KernelTransaction transaction;
 
     @Procedure("algo.triangle.stream")
-    @Description("CALL algo.triangle.stream(label, relationship, {concurrency:8}) " +
+    @Description("CALL algo.triangle.stream(label, relationship, {concurrency:4}) " +
             "YIELD nodeA, nodeB, nodeC - yield nodeA, nodeB and nodeC which form a triangle")
     public Stream<TriangleStream.Result> triangleStream(
             @Name(value = "label", defaultValue = "") String label,
@@ -67,7 +67,7 @@ public class TriangleProc {
     }
 
     @Procedure("algo.triangleCount.stream")
-    @Description("CALL algo.triangleCount.stream(label, relationship, {concurrency:8}) " +
+    @Description("CALL algo.triangleCount.stream(label, relationship, {concurrency:4}) " +
             "YIELD nodeId, triangles - yield nodeId, number of triangles")
     public Stream<TriangleCount.Result> triangleCountStream(
             @Name(value = "label", defaultValue = "") String label,
@@ -97,7 +97,7 @@ public class TriangleProc {
 
     @Procedure(value = "algo.triangleCount", mode = Mode.WRITE)
     @Description("CALL algo.triangleCount(label, relationship, " +
-            "{concurrency:8, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'}) " +
+            "{concurrency:4, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'}) " +
             "YIELD loadMillis, computeMillis, writeMillis, nodeCount, triangleCount, averageClusteringCoefficient")
     public Stream<Result> triangleCount(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
@@ -42,7 +42,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:8}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:8}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc2.java
@@ -42,7 +42,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:8}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:4}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc2 {
 
     @Procedure(value = "algo.unionFind.exp1.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:8}) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:4}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
@@ -42,7 +42,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition', concurrency:8}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:8}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc3.java
@@ -42,7 +42,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition', concurrency:8}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition', concurrency:4}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc3 {
 
     @Procedure(value = "algo.unionFind.exp2.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:8}) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0, concurrency:4}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
@@ -42,7 +42,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition'}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:8}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0,concurrency:8}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/UnionFindProc4.java
@@ -42,7 +42,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3", mode = Mode.WRITE)
     @Description("CALL algo.unionFind(label:String, relationship:String, " +
-            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:8}) " +
+            "{property:'weight', threshold:0.42, defaultValue:1.0, write: true, partitionProperty:'partition',concurrency:4}) " +
             "YIELD nodes, setCount, loadMillis, computeMillis, writeMillis")
     public Stream<UnionFindResult> unionFind(
             @Name(value = "label", defaultValue = "") String label,
@@ -81,7 +81,7 @@ public class UnionFindProc4 {
 
     @Procedure(value = "algo.unionFind.exp3.stream")
     @Description("CALL algo.unionFind.stream(label:String, relationship:String, " +
-            "{property:'propertyName', threshold:0.42, defaultValue:1.0,concurrency:8}) " +
+            "{property:'propertyName', threshold:0.42, defaultValue:1.0,concurrency:4}) " +
             "YIELD nodeId, setId - yields a setId to each node id")
     public Stream<DisjointSetStruct.Result> unionFindStream(
             @Name(value = "label", defaultValue = "") String label,

--- a/doc/betweenness-centrality.adoc
+++ b/doc/betweenness-centrality.adoc
@@ -92,7 +92,8 @@ We can see that Alice is the main broker in this network and Charles is a minor 
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.betweenness(label:String, relationship:String, {direction:'out',write:true, stats:true, writeProperty:'centrality',concurrency: 1}) 
+CALL algo.betweenness(label:String, relationship:String, 
+{direction:'out',write:true, stats:true, writeProperty:'centrality',concurrency:1}) 
 YIELD nodes, minCentrality, maxCentrality, sumCentrality, loadMillis, computeMillis, writeMillis 
 - calculates betweenness centrality and potentially writes back
 ----
@@ -132,7 +133,9 @@ YIELD nodes, minCentrality, maxCentrality, sumCentrality, loadMillis, computeMil
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.betweenness.stream(label:String, relationship:String,{direction:'out',concurrency:1}) YIELD nodeId, centrality - yields centrality for each node
+CALL algo.betweenness.stream(label:String, relationship:String,
+{direction:'out',concurrency:1}) 
+YIELD nodeId, centrality - yields centrality for each node
 ----
 
 .Parameters
@@ -198,6 +201,7 @@ We support the following versions of the betweenness centrality algorithm:
 - brandes-like algorithm which uses successor sets instead of predecessor sets
 - The algorithm is based on Brandes definition but with some changes
  regarding the dependency-accumulation step.
+- Does not support undirected graph 
 
 == References
 

--- a/doc/closeness-centrality.adoc
+++ b/doc/closeness-centrality.adoc
@@ -108,7 +108,7 @@ k/S| 0.4  0.57  0.67  0.57   0.4     // normalized closeness centrality
 [source,cypher]
 ----
 CALL algo.closeness(label:String, relationship:String, 
-{write:true, writeProperty:'centrality',graph:'heavy', concurrency:8}) 
+{write:true, writeProperty:'centrality',graph:'heavy', concurrency:4}) 
 YIELD nodes,loadMillis, computeMillis, writeMillis 
 - calculates closeness centrality and potentially writes back
 ----
@@ -141,7 +141,7 @@ YIELD nodes,loadMillis, computeMillis, writeMillis
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.closeness.stream(label:String, relationship:String,{concurrency:8}) 
+CALL algo.closeness.stream(label:String, relationship:String,{concurrency:4}) 
 YIELD nodeId, centrality - yields centrality for each node
 ----
 

--- a/doc/closeness-centrality.adoc
+++ b/doc/closeness-centrality.adoc
@@ -107,7 +107,8 @@ k/S| 0.4  0.57  0.67  0.57   0.4     // normalized closeness centrality
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.closeness(label:String, relationship:String, {write:true, writeProperty:'centrality',graph:'heavy'}) 
+CALL algo.closeness(label:String, relationship:String, 
+{write:true, writeProperty:'centrality',graph:'heavy', concurrency:8}) 
 YIELD nodes,loadMillis, computeMillis, writeMillis 
 - calculates closeness centrality and potentially writes back
 ----
@@ -119,6 +120,7 @@ YIELD nodes,loadMillis, computeMillis, writeMillis
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | write | boolean | true | yes | if result should be written back as node property
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | writeProperty | string | 'centrality' | yes | property name written back to
 | graph | string | 'heavy' | yes | use 'heavy' when describing the subset of the graph with label and relationship-type parameter, 'cypher' for describing the subset with cypher node-statement and relationship-statement
 |===
@@ -139,7 +141,8 @@ YIELD nodes,loadMillis, computeMillis, writeMillis
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.closeness.stream(label:String, relationship:String) YIELD nodeId, centrality - yields centrality for each node
+CALL algo.closeness.stream(label:String, relationship:String,{concurrency:8}) 
+YIELD nodeId, centrality - yields centrality for each node
 ----
 
 .Parameters
@@ -148,6 +151,7 @@ CALL algo.closeness.stream(label:String, relationship:String) YIELD nodeId, cent
 | name | type | default | optional | description
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all relationships
+| concurrency | int | available CPUs | yes | number of concurrent threads
 |===
 
 .Results

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -126,7 +126,7 @@ We can observe, that because the weight of the relationship betwen Bridget and A
 [source,cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy',concurrency:8}) 
+defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy',concurrency:4}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 - finds connected partitions and potentially writes back to the node as a property partition. 
 
@@ -162,7 +162,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0, concurrency:8}) 
+CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0, concurrency:4}) 
 YIELD nodeId, setId - yields a setId to each node id
 ----
 

--- a/doc/connected-components.adoc
+++ b/doc/connected-components.adoc
@@ -84,7 +84,8 @@ Results show us, that we have two distinct group of users that have no link betw
 [source,cypher]
 ----
 MATCH (u:User)
-RETURN distinct(u.partition) as partition,count(*) as size_of_partition ORDER by size_of_partition DESC 
+RETURN u.partition as partition,count(*) as size_of_partition 
+ORDER by size_of_partition DESC LIMIT 20 
 ----
 === Weighted version:
 
@@ -125,7 +126,7 @@ We can observe, that because the weight of the relationship betwen Bridget and A
 [source,cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy'}) 
+defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy',concurrency:8}) 
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 - finds connected partitions and potentially writes back to the node as a property partition. 
 
@@ -142,6 +143,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 | partitionProperty | string | 'partition' | yes | property name written back the id of the partition particular node belongs to
 | threshold | float | null | yes | value of the weight above which the relationship is not thrown away
 | defaultValue | float | null | yes | default value of the weight in case it is missing or invalid
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | graph | string | 'heavy' | yes | use 'heavy' when describing the subset of the graph with label and relationship-type parameter, 'cypher' for describing the subset with cypher node-statement and relationship-statement
 |===
 
@@ -160,7 +162,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0}) 
+CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0, concurrency:8}) 
 YIELD nodeId, setId - yields a setId to each node id
 ----
 
@@ -170,6 +172,7 @@ YIELD nodeId, setId - yields a setId to each node id
 | name | type | default | optional | description
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all relationships
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | weightProperty | string | null | yes | property name that contains weight, if null treats the graph as unweighted. Must be numeric.
 | threshold | float | null | yes | value of the weight above which the relationship is not thrown away
 | defaultValue | float | null | yes | default value of the weight in case it is missing or invalid
@@ -218,6 +221,10 @@ the calculation of the DSS is done by the ExecutorService.
 `algo.unionFind.exp3`
 
 - calculation and merge using forkJoinPool
+
+`algo.unionFind.mscoloring`
+
+- coloring based parallel algorithm
 
 
 == References

--- a/doc/label-propagation.adoc
+++ b/doc/label-propagation.adoc
@@ -81,7 +81,7 @@ YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, write, partitio
 [source,cypher]
 ----
 CALL algo.labelPropagation(label:String, relationship:String, direction:String, {iterations:1,
-weightProperty:'weight', partitionProperty:'partition', write:true}) 
+weightProperty:'weight', partitionProperty:'partition', write:true, concurrency:8}) 
 YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, write, weightProperty,
 partitionProperty - simple label propagation kernel
 ----
@@ -93,6 +93,7 @@ partitionProperty - simple label propagation kernel
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | direction | string | 'OUTGOING' | yes | relationship-direction to use in the algorithm
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | iterations | int | 1 | yes | number of iterations
 | weightProperty | string | 'weight' | yes | property name that contains weight. Must be numeric.
 | partitionProperty | string | 'partition' | yes | property name written back the partition of the graph in which the node reside
@@ -131,9 +132,9 @@ We support the following versions of the label propagation algorithms:
 
 == References
 
-* http://cpb.iphy.ac.cn/fileup/PDF/2014-9-098902.pdf
+* [0] http://cpb.iphy.ac.cn/fileup/PDF/2014-9-098902.pdf
 
-* http://shodhganga.inflibnet.ac.in/bitstream/10603/36003/4/chapter3.pdf
+* [1] http://shodhganga.inflibnet.ac.in/bitstream/10603/36003/4/chapter3.pdf
 
 ifdef::implementation[]
 // tag::implementation[]

--- a/doc/label-propagation.adoc
+++ b/doc/label-propagation.adoc
@@ -81,7 +81,7 @@ YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, write, partitio
 [source,cypher]
 ----
 CALL algo.labelPropagation(label:String, relationship:String, direction:String, {iterations:1,
-weightProperty:'weight', partitionProperty:'partition', write:true, concurrency:8}) 
+weightProperty:'weight', partitionProperty:'partition', write:true, concurrency:4}) 
 YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, write, weightProperty,
 partitionProperty - simple label propagation kernel
 ----

--- a/doc/label-propagation.adoc
+++ b/doc/label-propagation.adoc
@@ -132,9 +132,9 @@ We support the following versions of the label propagation algorithms:
 
 == References
 
-* [0] http://cpb.iphy.ac.cn/fileup/PDF/2014-9-098902.pdf
+* http://cpb.iphy.ac.cn/fileup/PDF/2014-9-098902.pdf
 
-* [1] http://shodhganga.inflibnet.ac.in/bitstream/10603/36003/4/chapter3.pdf
+* http://shodhganga.inflibnet.ac.in/bitstream/10603/36003/4/chapter3.pdf
 
 ifdef::implementation[]
 // tag::implementation[]

--- a/doc/pagerank.adoc
+++ b/doc/pagerank.adoc
@@ -129,7 +129,7 @@ CALL algo.pageRank.stream('Label1', 'TYPE1') YIELD node, score order by score de
 [source,cypher]
 ----
 CALL algo.pageRank(label:String, relationship:String, {iterations:20, dampingFactor:0.85, 
-write: true,writeProperty:'pagerank', concurrency:8}) 
+write: true,writeProperty:'pagerank', concurrency:4}) 
 YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, write, writeProperty 
 - calculates page rank and potentially writes back
 ----
@@ -168,7 +168,7 @@ YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, 
 [source,cypher]
 ----
 CALL algo.pageRank.stream(label:String, relationship:String, 
-{iterations:20, dampingFactor:0.85, concurrency:8})
+{iterations:20, dampingFactor:0.85, concurrency:4})
 YIELD node, score - calculates page rank and streams results
 ----
 

--- a/doc/pagerank.adoc
+++ b/doc/pagerank.adoc
@@ -129,7 +129,7 @@ CALL algo.pageRank.stream('Label1', 'TYPE1') YIELD node, score order by score de
 [source,cypher]
 ----
 CALL algo.pageRank(label:String, relationship:String, {iterations:20, dampingFactor:0.85, 
-write: true,writeProperty:'pagerank'}) 
+write: true,writeProperty:'pagerank', concurrency:8}) 
 YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, write, writeProperty 
 - calculates page rank and potentially writes back
 ----
@@ -141,6 +141,7 @@ YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, 
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | iterations | int | 20 | yes | how many iterations of page-rank to run
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | dampingFactor | float | 0.85 | yes | damping factor of the page-rank calculation
 | write | boolean | true | yes | if result should be written back as node property
 | writeProperty | string | 'pagerank' | yes | property name written back to
@@ -166,7 +167,8 @@ YIELD nodes, iterations, loadMillis, computeMillis, writeMillis, dampingFactor, 
 .running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.pageRank.stream(label:String, relationship:String, {iterations:20, dampingFactor:0.85})
+CALL algo.pageRank.stream(label:String, relationship:String, 
+{iterations:20, dampingFactor:0.85, concurrency:8})
 YIELD node, score - calculates page rank and streams results
 ----
 
@@ -177,6 +179,7 @@ YIELD node, score - calculates page rank and streams results
 | label  | string | null | yes | label to load from the graph, if null load all nodes
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | iterations | int | 20 | yes | how many iterations of page-rank to run
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | dampingFactor | float | 0.85 | yes | damping factor of the page-rank calculation
 |===
 

--- a/doc/strongly-connected-components.adoc
+++ b/doc/strongly-connected-components.adoc
@@ -81,7 +81,8 @@ RETURN distinct(u.partition) as partition,count(*) as size_of_partition ORDER by
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc(label:String, relationship:String, {write:true,partitionProperty:'partition',graph:'heavy'}) 
+CALL algo.scc(label:String, relationship:String, 
+{write:true,partitionProperty:'partition',concurrency:8, graph:'heavy'}) 
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
 - finds strongly connected partitions and potentially writes back to the node as a property partition. 
@@ -95,6 +96,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 | relationship | string | null | yes | relationship-type to load from the graph, if null load all nodes
 | write | boolean | true | yes | if result should be written back as node property
 | partitionProperty | string | 'partition' | yes | property name written back to
+| concurrency | int | available CPUs | yes | number of concurrent threads
 | graph | string | 'heavy' | yes | use 'heavy' when describing the subset of the graph with label and relationship-type parameter, 'cypher' for describing the subset with cypher node-statement and relationship-statement
 
 |===

--- a/doc/strongly-connected-components.adoc
+++ b/doc/strongly-connected-components.adoc
@@ -82,7 +82,7 @@ RETURN distinct(u.partition) as partition,count(*) as size_of_partition ORDER by
 [source,cypher]
 ----
 CALL algo.scc(label:String, relationship:String, 
-{write:true,partitionProperty:'partition',concurrency:8, graph:'heavy'}) 
+{write:true,partitionProperty:'partition',concurrency:4, graph:'heavy'}) 
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
 - finds strongly connected partitions and potentially writes back to the node as a property partition. 

--- a/doc/triangleCount.adoc
+++ b/doc/triangleCount.adoc
@@ -85,7 +85,7 @@ YIELD nodeId, triangles
 .returns a stream of triples with nodeIds for each triangle.
 [source,cypher]
 ----
-CALL algo.triangle.stream(label:String, relationship:String, {concurrency:8})
+CALL algo.triangle.stream(label:String, relationship:String, {concurrency:4})
 YIELD nodeA, nodeB, nodeC - yield nodeA, nodeB and nodeC which form a triangle
 ----
 
@@ -112,7 +112,7 @@ YIELD nodeA, nodeB, nodeC - yield nodeA, nodeB and nodeC which form a triangle
 .counts number of triangles a node is member of and returns a stream with nodeId and triangleCount
 [source,cypher]
 ----
-CALL algo.triangleCount.stream(label:String, relationship:String, {concurrency:8})
+CALL algo.triangleCount.stream(label:String, relationship:String, {concurrency:4})
 YIELD nodeId, triangles - yield nodeId, number of triangles
 ----
 
@@ -139,7 +139,7 @@ YIELD nodeId, triangles - yield nodeId, number of triangles
 [source,cypher]
 ----
 CALL algo.triangleCount(label:String, relationship:String, 
-{concurrency:8, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'}) 
+{concurrency:4, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'}) 
 YIELD loadMillis, computeMillis, writeMillis, nodeCount, triangleCount, averageClusteringCoefficient
 ----
 


### PR DESCRIPTION
I have found few things, that might be changed, so that as default we use as many threads as possible...

algo.scc.multistep uses:

```
configuration.getNumber("concurrency", 1).intValue()
```

algo.scc.forwardBackward uses:

```
 configuration.getConcurrency(1))
```

And correct me if I am wrong `algo.betweenness.exp1` seems to have hard-coded 4 threads:

```
 ParallelUtil.iterateParallel(executorService, nodeCount, 4, i -> {
            d.set(i, -1);
            sigma.set(i, 0);
            offsets.set(i, 0);
        });
```
when i compare it to:

```
ParallelUtil.iterateParallel(executorService, nodeCount, Pools.DEFAULT_CONCURRENCY, i -> {
                centrality.set(i, centrality.get(i) / 2.0);
            });
```

I can easily change `algo.scc.*` to default to that it will use maximum threads possible
```
configuration.getConcurrency()
```
