### PR TITLE
Allow 'BOTH' for LPA

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
@@ -22,12 +22,9 @@ import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Stream;
-
-import static java.lang.String.format;
 
 public final class LabelPropagationProc {
 
@@ -61,9 +58,10 @@ public final class LabelPropagationProc {
 
         final ProcedureConfiguration configuration = ProcedureConfiguration.create(config)
                 .overrideNodeLabelOrQuery(label)
-                .overrideRelationshipTypeOrQuery(relationshipType);
+                .overrideRelationshipTypeOrQuery(relationshipType)
+                .overrideDirection(directionName);
 
-        final Direction direction = parseDirection(directionName);
+        final Direction direction = configuration.getDirection(Direction.OUTGOING);
         final int iterations = configuration.getIterations(DEFAULT_ITERATIONS);
         final int batchSize = configuration.getBatchSize();
         final int concurrency = configuration.getConcurrency();
@@ -165,37 +163,5 @@ public final class LabelPropagationProc {
                             IntArrayTranslator.INSTANCE
                 );
         }
-    }
-
-    private static final Direction[] ALLOWED_DIRECTION = Arrays
-            .stream(Direction.values())
-            .filter(d -> d != Direction.BOTH)
-            .toArray(Direction[]::new);
-
-    private static Direction parseDirection(String directionString) {
-        if (null == directionString) {
-            return Direction.OUTGOING;
-        }
-        Direction direction;
-        try {
-            direction = Direction.valueOf(directionString.toUpperCase());
-        } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    format(
-                            "Cannot convert value '%s' to Direction. Legal values are '%s'.",
-                            directionString,
-                            Arrays.toString(ALLOWED_DIRECTION)
-                    )
-            );
-        }
-        if (direction == Direction.BOTH) {
-            throw new IllegalArgumentException(
-                    format(
-                            "Direction BOTH is not allowed. Legal values are '%s'.",
-                            Arrays.toString(ALLOWED_DIRECTION)
-                    )
-            );
-        }
-        return direction;
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -6,10 +6,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.graphalgo.LabelPropagationProc;
-import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -18,12 +16,10 @@ import org.neo4j.graphalgo.TestDatabaseCreator;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 public class LabelPropagationProcIntegrationTest {
@@ -168,20 +164,6 @@ public class LabelPropagationProcIntegrationTest {
         runQuery(query);
         runQuery(check, row ->
                 assertEquals(42, row.getNumber("partition").intValue()));
-    }
-
-    @Test
-    public void shouldNotPropagateBoth() throws Exception {
-        String query = "CALL algo.labelPropagation('A', 'X', 'BOTH')";
-        try {
-            runQuery(query);
-            fail();
-        } catch (QueryExecutionException e) {
-            Throwable cause = Exceptions.peel(e, ((Predicate<Throwable>) IllegalArgumentException.class::isInstance).negate());
-            assertEquals(
-                    "Direction BOTH is not allowed. Legal values are '[OUTGOING, INCOMING]'.",
-                    cause.getMessage());
-        }
     }
 
     private void runQuery(String query) {


### PR DESCRIPTION
I can't recall why it restricted it in the first place and I don't see a technical reason why it shouldn't be supported.

Fixes #289.