### PR TITLE
Test and support "undirected" weights when loading as BOTH

### DIFF
--- a/core/src/main/java/org/neo4j/graphalgo/api/Graph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/Graph.java
@@ -6,7 +6,7 @@ package org.neo4j.graphalgo.api;
  *
  * @author mknblch
  */
-public interface Graph extends IdMapping, Degrees, NodeIterator, BatchNodeIterable, RelationshipIterator, WeightedRelationshipIterator {
+public interface Graph extends IdMapping, Degrees, NodeIterator, BatchNodeIterable, RelationshipWeights, RelationshipIterator, WeightedRelationshipIterator {
 
     /**
      * release resources which are not part of the result or IdMapping

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeGraph.java
@@ -4,7 +4,6 @@ package org.neo4j.graphalgo.api;
 import org.neo4j.collection.primitive.PrimitiveIntIterable;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphdb.Direction;
 
 import java.util.Collection;
@@ -58,6 +57,14 @@ public interface HugeGraph extends HugeIdMapping, HugeDegrees, HugeNodeIterator,
     default PrimitiveIntIterator nodeIterator() {
         return new LongToIntIterator(hugeNodeIterator());
     }
+
+    @Override
+    default double weightOf(
+            int sourceNodeId,
+            int targetNodeId) {
+        return weightOf((long) sourceNodeId, (long) targetNodeId);
+    }
+
 
     final class LongToIntIterator implements PrimitiveIntIterator {
         private final PrimitiveLongIterator iter;

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeRelationshipWeights.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeRelationshipWeights.java
@@ -15,14 +15,4 @@ public interface HugeRelationshipWeights {
      * @return the weight
      */
     double weightOf(long sourceNodeId, long targetNodeId);
-
-    /**
-     * get weight between source and target node id or the default weight
-     *
-     * @param sourceNodeId  source node
-     * @param targetNodeId  target node
-     * @param defaultWeight default weight
-     * @return the weight
-     */
-    double weightOf(long sourceNodeId, long targetNodeId, double defaultWeight);
 }

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeWeightMapping.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeWeightMapping.java
@@ -8,12 +8,6 @@ public interface HugeWeightMapping {
     double weight(long source, long target);
 
     /**
-     * returns the weight for the relationship defined by their start and end nodes
-     * or the default value if no such weight exists
-     */
-    double weight(long source, long target, double defaultValue);
-
-    /**
      * release internal data structures and return an estimate how many
      * bytes were freed.
      * The mapping is not usable afterwards.

--- a/core/src/main/java/org/neo4j/graphalgo/core/HugeNullWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/HugeNullWeightMap.java
@@ -22,14 +22,6 @@ public class HugeNullWeightMap implements HugeWeightMapping {
     }
 
     @Override
-    public double weight(
-            final long source,
-            final long target,
-            final double defaultValue) {
-        return defaultValue;
-    }
-
-    @Override
     public long release() {
         return 0L;
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/HugeWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/HugeWeightMap.java
@@ -20,20 +20,20 @@ public final class HugeWeightMap implements HugeWeightMapping {
         return weights.getOrDefault(source, target, defaultValue);
     }
 
-    @Override
-    public double weight(
-            final long source,
-            final long target,
-            final double defaultValue) {
-        return weights.getOrDefault(source, target, defaultValue);
-    }
-
     public void put(long key1, long key2, Object value) {
         double doubleVal = RawValues.extractValue(value, defaultValue);
         if (doubleVal == defaultValue) {
             return;
         }
         weights.put(key1, key2, doubleVal);
+    }
+
+    public double defaultValue() {
+        return defaultValue;
+    }
+
+    public void put(long key1, long key2, double value) {
+        weights.put(key1, key2, value);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
@@ -58,7 +58,7 @@ public final class WeightMap implements WeightMapping {
         put(id, doubleVal);
     }
 
-    private void put(long key, double value) {
+    public void put(long key, double value) {
         weights.put(key, value);
     }
 
@@ -83,5 +83,9 @@ public final class WeightMap implements WeightMapping {
     @Override
     public int size() {
         return weights.size();
+    }
+
+    public double defaultValue() {
+        return defaultValue;
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
@@ -15,7 +15,7 @@ import java.util.function.IntPredicate;
  *
  * @author mknblch
  */
-public class HeavyGraph implements Graph, RelationshipWeights, NodeWeights, NodeProperties {
+public class HeavyGraph implements Graph, NodeWeights, NodeProperties {
 
     private final IdMap nodeIdMap;
     private AdjacencyMatrix container;

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
@@ -4,6 +4,7 @@ import org.neo4j.collection.primitive.PrimitiveIntIterable;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphalgo.api.*;
 import org.neo4j.graphalgo.core.IdMap;
+import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphdb.Direction;
 
 import java.util.Collection;
@@ -90,7 +91,10 @@ public class HeavyGraph implements Graph, RelationshipWeights, NodeWeights, Node
 
     @Override
     public double weightOf(final int sourceNodeId, final int targetNodeId) {
-        return relationshipWeights.get(sourceNodeId, targetNodeId);
+        long relId = container.isBoth
+                ? RawValues.combineSorted(sourceNodeId, targetNodeId)
+                : RawValues.combineIntInt(sourceNodeId, targetNodeId);
+        return relationshipWeights.get(relId);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
@@ -246,7 +246,7 @@ public class HugeGraphImpl implements HugeGraph {
         consumeNodes(node, cursor, (s, t) -> consumer.accept(
                 (int) s,
                 (int) t,
-                RawValues.combineIntInt((int) s, (int) t)));
+                RawValues.combineIntInt((int) t, (int) s)));
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
@@ -71,6 +71,7 @@ public class HugeGraphImpl implements HugeGraph {
     private ByteArray.DeltaCursor empty;
     private ByteArray.DeltaCursor inCache;
     private ByteArray.DeltaCursor outCache;
+    private final boolean isBoth;
 
     HugeGraphImpl(
             final AllocationTracker tracker,
@@ -90,6 +91,7 @@ public class HugeGraphImpl implements HugeGraph {
         inCache = newCursor(this.inAdjacency);
         outCache = newCursor(this.outAdjacency);
         empty = inCache == null ? newCursor(this.outAdjacency) : newCursor(this.inAdjacency);
+        isBoth = inAdjacency != null && outAdjacency != null;
     }
 
     @Override
@@ -114,15 +116,10 @@ public class HugeGraphImpl implements HugeGraph {
 
     @Override
     public double weightOf(final long sourceNodeId, final long targetNodeId) {
+        if (isBoth && sourceNodeId > targetNodeId) {
+            return weights.weight(targetNodeId, sourceNodeId);
+        }
         return weights.weight(sourceNodeId, targetNodeId);
-    }
-
-    @Override
-    public double weightOf(
-            final long sourceNodeId,
-            final long targetNodeId,
-            final double defaultWeight) {
-        return weights.weight(sourceNodeId, targetNodeId, defaultWeight);
     }
 
     @Override
@@ -179,9 +176,7 @@ public class HugeGraphImpl implements HugeGraph {
             Direction direction,
             WeightedRelationshipConsumer consumer) {
         RelationshipConsumer nonWeighted = (s, t, relId) -> {
-            double weight = direction == Direction.OUTGOING
-                    ? weightOf((long) s, (long) t)
-                    : weightOf((long) t, (long) s);
+            double weight = weightOf((long) s, (long) t);
             return consumer.accept(
                     s,
                     t,
@@ -251,7 +246,7 @@ public class HugeGraphImpl implements HugeGraph {
         consumeNodes(node, cursor, (s, t) -> consumer.accept(
                 (int) s,
                 (int) t,
-                RawValues.combineIntInt((int) t, (int) s)));
+                RawValues.combineIntInt((int) s, (int) t)));
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/lightweight/GraphImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/lightweight/GraphImporter.java
@@ -3,6 +3,7 @@ package org.neo4j.graphalgo.core.lightweight;
 import org.neo4j.graphalgo.api.GraphSetup;
 import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.IdMap;
+import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.StatementTask;
 import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
 import org.neo4j.graphalgo.core.utils.paged.IntArray;
@@ -64,7 +65,8 @@ final class GraphImporter extends StatementTask<LightGraph, EntityNotFoundExcept
                         relationId,
                         Direction.INCOMING,
                         inAdjacency.newBulkAdder(),
-                        weights);
+                        weights,
+                        loadOutgoing ? RawValues.BOTH : RawValues.OUTGOING);
             }
             if (loadOutgoing) {
                 outOffsets = new long[nodeCount + 1];
@@ -77,14 +79,11 @@ final class GraphImporter extends StatementTask<LightGraph, EntityNotFoundExcept
                         relationId,
                         Direction.OUTGOING,
                         outAdjacency.newBulkAdder(),
-                        weights);
-
-
+                        weights,
+                        loadIncoming ? RawValues.BOTH : RawValues.OUTGOING);
             }
 
-            final RelationshipImport importer = RelationshipImport.combine(
-                    inImporter,
-                    outImporter);
+            final RelationshipImport importer = RelationshipImport.combine(outImporter, inImporter);
             final long[] ids = mapping.mappedIds();
             final int length = mapping.size();
             for (int i = 0; i < length; i++) {

--- a/core/src/main/java/org/neo4j/graphalgo/core/lightweight/LightGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/lightweight/LightGraph.java
@@ -169,7 +169,7 @@ public class LightGraph implements Graph {
             final int node,
             final RelationshipConsumer consumer) {
         IntArray.Cursor cursor = cursor(node, inOffsets, inAdjacency);
-        consumeNodes(node, cursor, inCombiner, consumer);
+        consumeNodes(node, cursor, (t, h) -> RawValues.combineIntInt(h, t), consumer);
         inAdjacency.returnCursor(cursor);
     }
 
@@ -177,7 +177,7 @@ public class LightGraph implements Graph {
             final int node,
             final RelationshipConsumer consumer) {
         IntArray.Cursor cursor = cursor(node, outOffsets, outAdjacency);
-        consumeNodes(node, cursor, outCombiner, consumer);
+        consumeNodes(node, cursor, RawValues.OUTGOING, consumer);
         outAdjacency.returnCursor(cursor);
     }
 
@@ -185,7 +185,7 @@ public class LightGraph implements Graph {
             final int node,
             final WeightedRelationshipConsumer consumer) {
         IntArray.Cursor cursor = cursor(node, inOffsets, inAdjacency);
-        consumeNodes(node, cursor, inCombiner, consumer);
+        consumeNodes(node, cursor, (t, h) -> RawValues.combineIntInt(h, t), inCombiner, consumer);
         inAdjacency.returnCursor(cursor);
     }
 
@@ -193,7 +193,7 @@ public class LightGraph implements Graph {
             final int node,
             final WeightedRelationshipConsumer consumer) {
         IntArray.Cursor cursor = cursor(node, outOffsets, outAdjacency);
-        consumeNodes(node, cursor, outCombiner, consumer);
+        consumeNodes(node, cursor, RawValues.OUTGOING, outCombiner, consumer);
         outAdjacency.returnCursor(cursor);
     }
 
@@ -207,6 +207,7 @@ public class LightGraph implements Graph {
             int startNode,
             IntArray.Cursor cursor,
             IdCombiner relId,
+            IdCombiner weightId,
             WeightedRelationshipConsumer consumer) {
         //noinspection UnnecessaryLocalVariable – prefer access of local var in loop
         final WeightMapping weightMap = this.weightMapping;
@@ -221,7 +222,7 @@ public class LightGraph implements Graph {
                         startNode,
                         targetNode,
                         relationId,
-                        weightMap.get(relationId)
+                        weightMap.get(weightId.apply(startNode, targetNode))
                 );
             }
         }

--- a/core/src/main/java/org/neo4j/graphalgo/core/lightweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/lightweight/RelationshipImporter.java
@@ -4,7 +4,6 @@ import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.IdMap;
 import org.neo4j.graphalgo.core.WeightMap;
 import org.neo4j.graphalgo.core.utils.IdCombiner;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.paged.IntArray;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.api.ReadOperations;
@@ -34,7 +33,8 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
             int[] relationId,
             Direction direction,
             IntArray.BulkAdder bulkAdder,
-            WeightMapping weights) {
+            WeightMapping weights,
+            IdCombiner combiner) {
         if (weights instanceof WeightMap) {
             return new WithWeights(
                     mapping,
@@ -43,6 +43,7 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
                     readOp,
                     direction,
                     (WeightMap) weights,
+                    combiner,
                     bulkAdder);
         } else {
             return new RelationshipImporter(
@@ -140,11 +141,12 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
                 ReadOperations readOp,
                 Direction direction,
                 WeightMap weights,
+                IdCombiner combiner,
                 IntArray.BulkAdder bulkAdder) {
             super(readOp, mapping, offsets, relationId, direction, bulkAdder);
             this.weights = weights;
             this.weightId = weights.propertyId();
-            this.idCombiner = RawValues.combiner(direction);
+            this.idCombiner = combiner;
         }
 
         @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
@@ -3,6 +3,7 @@ package org.neo4j.graphalgo.core.neo4jview;
 import org.neo4j.graphalgo.api.Graph;
 import org.neo4j.graphalgo.api.GraphFactory;
 import org.neo4j.graphalgo.api.GraphSetup;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 public final class GraphViewFactory extends GraphFactory {
@@ -15,8 +16,16 @@ public final class GraphViewFactory extends GraphFactory {
 
     @Override
     public Graph build() {
+        final Direction direction;
+        if (setup.loadOutgoing) {
+            direction = setup.loadIncoming ? Direction.BOTH : Direction.OUTGOING;
+        } else {
+            direction = setup.loadIncoming ? Direction.INCOMING : null;
+        }
+
         return new GraphView(
                 api,
+                direction,
                 setup.startLabel,
                 setup.relationshipType,
                 setup.relationWeightPropertyName,

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/RawValues.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/RawValues.java
@@ -10,7 +10,6 @@ import org.neo4j.graphdb.Direction;
 public class RawValues {
 
     public static final IdCombiner OUTGOING = RawValues::combineIntInt;
-    public static final IdCombiner INCOMING = RawValues::combineReverseIntInt;
     public static final IdCombiner BOTH = RawValues::combineSorted;
 
     /**
@@ -25,18 +24,6 @@ public class RawValues {
         return ((long) head << 32) | (long) tail & 0xFFFFFFFFL;
     }
 
-    /**
-     * shifts tail into the most significant 4 bytes of the long
-     * and places the head in the least significant bytes
-     *
-     * @param head an arbitrary int value
-     * @param tail an arbitrary int value
-     * @return combination of head and tail
-     */
-    public static long combineReverseIntInt(int head, int tail) {
-        return ((long) tail << 32) | (long) head & 0xFFFFFFFFL;
-    }
-
     public static long combineSorted(int head, int tail) {
         return head <= tail
                 ? combineIntInt(head, tail)
@@ -48,7 +35,7 @@ public class RawValues {
             case OUTGOING:
                 return combineIntInt(head, tail);
             case INCOMING:
-                return combineReverseIntInt(head, tail);
+                return combineIntInt(tail, head);
             case BOTH:
                 return combineSorted(head, tail);
             default:
@@ -57,16 +44,7 @@ public class RawValues {
     }
 
     public static IdCombiner combiner(Direction direction) {
-        switch (direction) {
-            case OUTGOING:
-                return OUTGOING;
-            case INCOMING:
-                return INCOMING;
-            case BOTH:
-                return BOTH;
-            default:
-                throw new IllegalArgumentException("Unkown direction: " + direction);
-        }
+        return (direction == Direction.BOTH) ? BOTH : OUTGOING;
     }
 
     /**

--- a/tests/src/test/java/org/neo4j/graphalgo/core/CypherExporter.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/CypherExporter.java
@@ -40,7 +40,7 @@ final class CypherExporter {
         return s
                 .append("  (n")
                 .append(rel.getStartNode().getId())
-                .append(")-[")
+                .append(")-[:")
                 .append(rel.getType().name())
                 .append(props(rel, s))
                 .append("]->")

--- a/tests/src/test/java/org/neo4j/graphalgo/core/WeightMapImportTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/WeightMapImportTest.java
@@ -1,83 +1,145 @@
 package org.neo4j.graphalgo.core;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.graphalgo.LouvainProc;
-import org.neo4j.graphalgo.TestDatabaseCreator;
+import org.junit.rules.ErrorCollector;
+import org.neo4j.graphalgo.api.WeightedRelationshipConsumer;
 import org.neo4j.graphalgo.core.heavyweight.HeavyGraph;
 import org.neo4j.graphalgo.core.heavyweight.HeavyGraphFactory;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
-import static org.junit.Assert.assertEquals;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
 
 /**
  * @author mknblch
  */
-@Ignore("Issue #444")
 public class WeightMapImportTest {
 
-    private static GraphDatabaseAPI db;
-    private static HeavyGraph graph;
+    @Rule
+    public ImpermanentDatabaseRule DB = new ImpermanentDatabaseRule();
 
-    @BeforeClass
-    public static void setupGraph() throws KernelException {
+    @Rule
+    public ErrorCollector collector = new ErrorCollector();
 
-        final String cypher =
-                "CREATE (a:Node {name:'a'})\n" +
-                        "CREATE (b:Node {name:'b'})\n" +
-                        "CREATE (a)-[:TYPE {w:1}]->(b)";
+    private HeavyGraph graph;
 
+    @Test
+    public void testWeightsOfInterconnectedNodesWithOutgoing() {
+        setup("CREATE (a:N),(b:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(a)", Direction.OUTGOING);
 
-        db = TestDatabaseCreator.createTestDatabase();
-
-        db.getDependencyResolver()
-                .resolveDependency(Procedures.class)
-                .registerProcedure(LouvainProc.class);
-
-        try (Transaction tx = db.beginTx()) {
-            db.execute(cypher);
-            tx.success();
-        }
-
-        graph = (HeavyGraph) new GraphLoader(db)
-                .withAnyRelationshipType()
-                .withAnyLabel()
-                .withoutNodeProperties()
-                .withRelationshipWeightsFromProperty("w", 0.0)
-                .load(HeavyGraphFactory.class);
-
-    }
-
-    @AfterClass
-    public static void tearDown() {
-        if (db != null) db.shutdown();
-    }
-
-    private String getName(long nodeId) {
-        String[] name = {""};
-        db.execute(String.format("MATCH (n) WHERE id(n) = %d RETURN n", nodeId)).accept(row -> {
-            name[0] = (String) row.getNode("n").getProperty("name");
-            return true;
-        });
-        return name[0];
+        checkWeight(0, Direction.OUTGOING, 1.0);
+        checkWeight(1, Direction.OUTGOING, 2.0);
     }
 
     @Test
-    public void testWeights() throws Exception {
-        graph.forEachNode(node -> {
-            graph.forEachRelationship(node, Direction.BOTH, (sourceNodeId, targetNodeId, relationId) -> {
-                assertEquals(String.format("wrong weight in (%s)->(%s)", getName(sourceNodeId), getName(targetNodeId)),
-                        1.0,
-                        graph.weightOf(sourceNodeId, targetNodeId), 0.0);
-                return true;
-            });
+    public void testWeightsOfTriangledNodesWithOutgoing() {
+        setup("CREATE (a:N),(b:N),(c:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(c),(c)-[:R{w:3}]->(a)", Direction.OUTGOING);
+
+        checkWeight(0, Direction.OUTGOING, 1.0);
+        checkWeight(1, Direction.OUTGOING, 2.0);
+        checkWeight(2, Direction.OUTGOING, 3.0);
+    }
+
+    @Test
+    public void testWeightsOfInterconnectedNodesWithIncoming() {
+        setup("CREATE (a:N),(b:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(a)", Direction.INCOMING);
+
+        checkWeight(0, Direction.INCOMING, 2.0);
+        checkWeight(1, Direction.INCOMING, 1.0);
+    }
+
+    @Test
+    public void testWeightsOfTriangledNodesWithIncoming() {
+        setup("CREATE (a:N),(b:N),(c:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(c),(c)-[:R{w:3}]->(a)", Direction.INCOMING);
+
+        checkWeight(0, Direction.INCOMING, 3.0);
+        checkWeight(1, Direction.INCOMING, 1.0);
+        checkWeight(2, Direction.INCOMING, 2.0);
+    }
+
+    @Test
+    public void testWeightsOfInterconnectedNodesWithBoth() {
+        setup("CREATE (a:N),(b:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(a)", Direction.BOTH);
+
+        // loading both overwrites the weights in the following order,
+        // which is specific to HeavyGraphFactory
+        // a->b: 1  |  a<-b: 2  |  b->a: 2  |  b<-a: 1
+        // therefore the final weight for in/outs of either a/b is 1,
+        // the weight of 2 is discarded
+
+        checkWeight(0, Direction.OUTGOING, 1.0);
+        checkWeight(1, Direction.OUTGOING, 1.0);
+
+        checkWeight(0, Direction.INCOMING, 1.0);
+        checkWeight(1, Direction.INCOMING, 1.0);
+
+        checkWeight(0, Direction.BOTH, 1.0, 1.0);
+        checkWeight(1, Direction.BOTH, 1.0, 1.0);
+    }
+
+    @Test
+    public void testWeightsOfTriangledNodesWithBoth() {
+        setup("CREATE (a:N),(b:N),(c:N) CREATE (a)-[:R{w:1}]->(b),(b)-[:R{w:2}]->(c),(c)-[:R{w:3}]->(a)", Direction.BOTH);
+
+        checkWeight(0, Direction.OUTGOING, 1.0);
+        checkWeight(1, Direction.OUTGOING, 2.0);
+        checkWeight(2, Direction.OUTGOING, 3.0);
+
+        checkWeight(0, Direction.INCOMING, 3.0);
+        checkWeight(1, Direction.INCOMING, 1.0);
+        checkWeight(2, Direction.INCOMING, 2.0);
+
+        checkWeight(0, Direction.BOTH, 3.0, 1.0);
+        checkWeight(1, Direction.BOTH, 1.0, 2.0);
+        checkWeight(2, Direction.BOTH, 2.0, 3.0);
+    }
+
+    private void setup(String cypher, Direction direction) {
+        DB.execute(cypher);
+        graph = (HeavyGraph) new GraphLoader(DB)
+                .withAnyRelationshipType()
+                .withAnyLabel()
+                .withoutNodeProperties()
+                .withDirection(direction)
+                .withRelationshipWeightsFromProperty("w", 0.0)
+                .load(HeavyGraphFactory.class);
+    }
+
+    private void checkWeight(int nodeId, Direction direction, double... expecteds) {
+        graph.forEachRelationship(nodeId, direction, checks(direction, expecteds));
+    }
+
+    private WeightedRelationshipConsumer checks(Direction direction, double... expecteds) {
+        AtomicInteger i = new AtomicInteger();
+        int limit = expecteds.length;
+        return (s, t, r, w) -> {
+            String rel = String.format("(%d %s %d)", s, arrow(direction), t);
+            if (i.get() >= limit) {
+                collector.addError(new RuntimeException(String.format("Unexpected relationship: %s = %.1f", rel, w)));
+                return false;
+            }
+            double actual = graph.weightOf(s, t);
+            double expected = expecteds[i.getAndIncrement()];
+            collector.checkThat(String.format("%s (RW): %.1f != %.1f", rel, actual, expected), actual, is(closeTo(expected, 1e-4)));
+            collector.checkThat(String.format("%s (WRI): %.1f != %.1f", rel, w, expected), w, is(closeTo(expected, 1e-4)));
             return true;
-        });
+        };
+    }
+
+    private static String arrow(Direction direction) {
+        switch (direction) {
+            case OUTGOING:
+                return "->";
+            case INCOMING:
+                return "<-";
+            case BOTH:
+                return "<->";
+            default:
+                return "???";
+        }
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/core/WeightMapImportTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/WeightMapImportTest.java
@@ -11,6 +11,7 @@ import org.neo4j.graphalgo.api.WeightedRelationshipConsumer;
 import org.neo4j.graphalgo.core.heavyweight.HeavyGraphFactory;
 import org.neo4j.graphalgo.core.huge.HugeGraphFactory;
 import org.neo4j.graphalgo.core.lightweight.LightGraphFactory;
+import org.neo4j.graphalgo.core.neo4jview.GraphView;
 import org.neo4j.graphalgo.core.neo4jview.GraphViewFactory;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
@@ -21,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * @author mknblch
@@ -95,7 +97,9 @@ public class WeightMapImportTest {
         // which expects the GraphFactory to load OUTGOINGs before INCOMINGs
         //   (a)-[{w:1}]->(b)  |  (a)<-[{w:2}]-(b)  |  (b)-[{w:2}]->(a)  |  (b)<-[{w:1}]-(a)
         // therefore the final weight for in/outs of either a/b is 1,
-        // the weight of 2 is discarded
+        // the weight of 2 is discarded.
+        // This cannot be represented in the graph view
+        assumeFalse("GraphView is not able to represent the test case", graph instanceof GraphView);
 
         checkWeight(0, Direction.OUTGOING, 1.0);
         checkWeight(1, Direction.OUTGOING, 1.0);

--- a/tests/src/test/java/org/neo4j/graphalgo/core/neo4jview/GraphViewTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/neo4jview/GraphViewTest.java
@@ -4,6 +4,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.neo4j.graphalgo.SimpleGraphSetup;
 import org.neo4j.graphalgo.SimpleGraphTestCase;
+import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 /**
@@ -16,7 +17,7 @@ public class GraphViewTest extends SimpleGraphTestCase {
 
     @BeforeClass
     public static void setupGraph() {
-        graph = new GraphView((GraphDatabaseAPI) setup.getDb(), LABEL, RELATION, WEIGHT_PROPERTY, 0.0);
+        graph = new GraphView((GraphDatabaseAPI) setup.getDb(), Direction.BOTH, LABEL, RELATION, WEIGHT_PROPERTY, 0.0);
         v0 = 0;
         v1 = 1;
         v2 = 2;


### PR DESCRIPTION
This is somewhat of a follow-up to #444 and required for correct weighted Louvain.
The change is related to nodes that are connected to each other like so

```
CREATE (a), (b)
CREATE (a)-[{ weight: 1 }]->(b), (b)-[{weight: 2}]->(a)
```

When using BOTH to treat the graph as undirected (and only then), those two relationships are effectively one in terms of their weight, in which case we use a sorted (a,b | a <= b) as weight key. In practice, the last weight write wins. We can introduce a new configuration in a future issue that would allow the user to decide how to combine weights, e.g. a `WeightAccumulator` enum with `SUM`, `MIN`, `MAX`, `FWW`, `LWW` values.
Unfortunately, the GraphView is not able to merge those weights on-the-fly, at least not in a way that wouldn't be tailored to the unit test cases.