### PR TITLE
Proper undirected support for heavy and huge

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/TriangleProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/TriangleProc.java
@@ -19,8 +19,13 @@
 package org.neo4j.graphalgo;
 
 import org.neo4j.graphalgo.api.Graph;
+import org.neo4j.graphalgo.api.HugeGraph;
 import org.neo4j.graphalgo.core.GraphLoader;
 import org.neo4j.graphalgo.core.ProcedureConfiguration;
+import org.neo4j.graphalgo.core.ProcedureConstants;
+import org.neo4j.graphalgo.core.heavyweight.HeavyCypherGraphFactory;
+import org.neo4j.graphalgo.core.heavyweight.HeavyGraph;
+import org.neo4j.graphalgo.core.heavyweight.HeavyGraphFactory;
 import org.neo4j.graphalgo.core.utils.*;
 import org.neo4j.graphalgo.core.utils.paged.DoubleArray;
 import org.neo4j.graphalgo.core.utils.paged.PagedAtomicIntegerArray;
@@ -73,9 +78,14 @@ public class TriangleProc {
                 .withOptionalRelationshipType(configuration.getRelationshipOrQuery())
                 .withoutRelationshipWeights()
                 .withoutNodeWeights()
+                .withSort(true)
+                .asUndirected(true)
                 .init(log, label, relationship, configuration)
                 .withDirection(TriangleCountBase.D)
-                .load(configuration.getGraphImpl());
+                .load(configuration.getGraphImpl(
+                        HeavyGraph.TYPE,
+                        HeavyGraph.TYPE, HeavyCypherGraphFactory.TYPE, HugeGraph.TYPE
+                ));
 
         final TriangleStream triangleStream = new TriangleStream(graph, Pools.DEFAULT, configuration.getConcurrency())
                 .withProgressLogger(ProgressLogger.wrap(log, "triangleStream"))
@@ -105,7 +115,10 @@ public class TriangleProc {
                 .asUndirected(true)
                 .init(log, label, relationship, configuration)
                 .withDirection(TriangleCountBase.D)
-                .load(configuration.getGraphImpl());
+                .load(configuration.getGraphImpl(
+                        HeavyGraph.TYPE,
+                        HeavyGraph.TYPE, HeavyCypherGraphFactory.TYPE, HugeGraph.TYPE
+                ));
 
         return TriangleCountAlgorithm.instance(graph, Pools.DEFAULT, configuration.getConcurrency())
                 .withProgressLogger(ProgressLogger.wrap(log, "triangleCount"))
@@ -136,7 +149,10 @@ public class TriangleProc {
                 .asUndirected(true)
                 .init(log, label, relationship, configuration)
                 .withDirection(TriangleCountBase.D)
-                .load(configuration.getGraphImpl());
+                .load(configuration.getGraphImpl(
+                        HeavyGraph.TYPE,
+                        HeavyGraph.TYPE, HeavyCypherGraphFactory.TYPE, HugeGraph.TYPE
+                ));
 
         return new TriangleCountForkJoin(
                 graph,
@@ -177,7 +193,10 @@ public class TriangleProc {
                     .asUndirected(true)
                     .init(log, label, relationship, configuration)
                     .withDirection(TriangleCountBase.D)
-                    .load(configuration.getGraphImpl());
+                    .load(configuration.getGraphImpl(
+                            HeavyGraph.TYPE,
+                            HeavyGraph.TYPE, HeavyCypherGraphFactory.TYPE, HugeGraph.TYPE
+                    ));
         }
 
         final TerminationFlag terminationFlag = TerminationFlag.wrap(transaction);
@@ -294,7 +313,10 @@ public class TriangleProc {
                     .asUndirected(true)
                     .init(log, label, relationship, configuration)
                     .withDirection(TriangleCountBase.D)
-                    .load(configuration.getGraphImpl());
+                    .load(configuration.getGraphImpl(
+                            HeavyGraph.TYPE,
+                            HeavyGraph.TYPE, HeavyCypherGraphFactory.TYPE, HugeGraph.TYPE
+                    ));
         }
 
         final TerminationFlag terminationFlag = TerminationFlag.wrap(transaction);

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/louvain/ParallelLouvain.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/louvain/ParallelLouvain.java
@@ -116,12 +116,13 @@ public class ParallelLouvain extends Algorithm<ParallelLouvain> implements Louva
 
         final LongAdder adder = new LongAdder();
         ParallelUtil.iterateParallel(executorService, nodeCount, concurrency, node -> {
-            final int d = degrees.degree(node, Direction.BOTH);
+            final int d = degrees.degree(node, Direction.OUTGOING);
             sTot[node] = d;
             adder.add(d);
         });
-        m2 = adder.intValue() * 4.0; // 2m //
-        mq2 = 2.0 * Math.pow(adder.intValue(), 2.0); // 2m^2
+        final double allDegree = (double) adder.intValue();
+        this.m2 = allDegree * 4.0; // 2m //
+        mq2 = 2.0 * Math.pow(allDegree, 2.0); // 2m^2
     }
 
     /**
@@ -130,7 +131,7 @@ public class ParallelLouvain extends Algorithm<ParallelLouvain> implements Louva
      * @param targetCommunity communityId
      */
     private void assign(int node, int targetCommunity) { // TODO sync
-        final int d = degrees.degree(node, Direction.BOTH);
+        final int d = degrees.degree(node, Direction.OUTGOING);
 
         writeLock.lock();
         try {
@@ -148,7 +149,7 @@ public class ParallelLouvain extends Algorithm<ParallelLouvain> implements Louva
      */
     private int kIIn(int node, int targetCommunity) {
         int[] sum = {0}; // {ki, ki_in}
-        relationshipIterator.forEachRelationship(node, Direction.BOTH, (sourceNodeId, targetNodeId, relationId) -> {
+        relationshipIterator.forEachRelationship(node, Direction.OUTGOING, (sourceNodeId, targetNodeId, relationId) -> {
             if (targetCommunity == communityIds[targetNodeId]) {
                 sum[0]++;
             }
@@ -201,10 +202,10 @@ public class ParallelLouvain extends Algorithm<ParallelLouvain> implements Louva
                 bestGain = 0.0;
                 readLock.lock();
                 final int sourceCommunity = bestCommunity = communityIds[node];
-                final double mSource = (sTot[sourceCommunity] * degrees.degree(node, Direction.BOTH)) / mq2;
+                final double mSource = (sTot[sourceCommunity] * degrees.degree(node, Direction.OUTGOING)) / mq2;
                 readLock.unlock();
 
-                relationshipIterator.forEachRelationship(node, Direction.BOTH, (sourceNodeId, targetNodeId, relationId) -> {
+                relationshipIterator.forEachRelationship(node, Direction.OUTGOING, (sourceNodeId, targetNodeId, relationId) -> {
                     readLock.lock();
                     final int targetCommunity = communityIds[targetNodeId];
                     final double gain = kIIn(sourceNodeId, targetCommunity) / m2 - mSource;

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountBase.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountBase.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  */
 public abstract class TriangleCountBase<Coeff, Self extends TriangleCountBase<Coeff, Self>> extends Algorithm<Self> {
 
-    public static final Direction D = Direction.BOTH;
+    public static final Direction D = Direction.OUTGOING;
 
     private final AtomicInteger visitedNodes;
     private AtomicIntegerArray triangles;

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountForkJoin.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountForkJoin.java
@@ -66,7 +66,7 @@ public class TriangleCountForkJoin extends TriangleCountBase<AtomicDoubleArray, 
                 : new TriangleTask(0, nodeCount);
         triangleCount = pool.invoke(countTask);
         CoefficientTask coefficientTask = new CoefficientTask(
-                graph instanceof HugeGraph ? Direction.OUTGOING : Direction.BOTH,
+                Direction.OUTGOING,
                 0,
                 nodeCount);
         averageClusteringCoefficient = pool.invoke(coefficientTask);

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountQueue.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleCountQueue.java
@@ -57,7 +57,7 @@ public class TriangleCountQueue extends Algorithm<TriangleCountQueue> implements
         this.executorService = executorService;
         this.concurrency = concurrency;
         triangleCount = new LongAdder();
-        direction = Direction.BOTH;
+        direction = Direction.OUTGOING;
         queue = new AtomicInteger();
         this.nodeCount = Math.toIntExact(graph.nodeCount());
         triangles = new AtomicIntegerArray(nodeCount);

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleStream.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/TriangleStream.java
@@ -46,7 +46,7 @@ import java.util.stream.StreamSupport;
  */
 public class TriangleStream extends Algorithm<TriangleStream> {
 
-    public static final Direction D = Direction.BOTH;
+    public static final Direction D = Direction.OUTGOING;
     private Graph graph;
     private ExecutorService executorService;
     private final AtomicInteger queue;
@@ -173,7 +173,7 @@ public class TriangleStream extends Algorithm<TriangleStream> {
             while (!nodes.isEmpty()) {
                 final int node = nodes.pop();
                 graph.forEachRelationship(node, D, (s, t, r) -> {
-                    if (t > s && graph.exists(t, nodeId, Direction.BOTH)) {
+                    if (t > s && graph.exists(t, nodeId, D)) {
                         emit(nodeId, s, t);
                     }
                     return running();

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/DirectionParam.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/DirectionParam.java
@@ -18,17 +18,59 @@
  */
 package org.neo4j.graphalgo.bench;
 
+import org.neo4j.graphalgo.core.GraphLoader;
 import org.neo4j.graphdb.Direction;
 
-public enum DirectionParam {
-    IN(Direction.INCOMING),
-    OUT(Direction.OUTGOING),
-    BOTH(Direction.BOTH),
-    NONE(null);
+import java.util.function.Function;
 
-    final Direction direction;
+public enum DirectionParam implements Function<GraphLoader, GraphLoader> {
 
-    DirectionParam(Direction direction) {
-        this.direction = direction;
+    IN {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.INCOMING);
+        }
+    },
+    IN_SORT {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.INCOMING).withSort(true);
+        }
+    },
+    OUT {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.OUTGOING);
+        }
+    },
+    OUT_SORT {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.OUTGOING).withSort(true);
+        }
+    },
+    BOTH {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.BOTH);
+        }
+    },
+    BOTH_SORT {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(Direction.BOTH).withSort(true);
+        }
+    },
+    UNDIRECTED {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.asUndirected(true).withDirection(Direction.BOTH).withSort(true);
+        }
+    },
+    NONE {
+        @Override
+        public GraphLoader apply(final GraphLoader graphLoader) {
+            return graphLoader.withDirection(null);
+        }
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
@@ -269,13 +269,14 @@ public class ProcedureConfiguration {
         return Directions.fromString(getDirectionName(defaultDirection.name()));
     }
 
+    public String getGraphName(String defaultValue) {
+        return getString(ProcedureConstants.GRAPH_IMPL_PARAM, defaultValue);
+    }
+
     public Class<? extends GraphFactory> getGraphImpl() {
         return getGraphImpl(ProcedureConstants.DEFAULT_GRAPH_IMPL);
     }
 
-    public String getGraphName(String defaultValue) {
-        return  getString(ProcedureConstants.GRAPH_IMPL_PARAM,defaultValue);
-    }
     /**
      * return the Graph-Implementation Factory class
      *
@@ -309,7 +310,6 @@ public class ProcedureConfiguration {
         return name != null && !name.trim().isEmpty() && !RESERVED.contains(name.trim().toLowerCase());
     }
 
-    @SafeVarargs
     public final Class<? extends GraphFactory> getGraphImpl(
             String defaultImpl,
             String ... alloweds) {

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/HeavyGraph.java
@@ -22,7 +22,6 @@ import org.neo4j.collection.primitive.PrimitiveIntIterable;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphalgo.api.*;
 import org.neo4j.graphalgo.core.IdMap;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphdb.Direction;
 
 import java.util.Collection;
@@ -112,10 +111,7 @@ public class HeavyGraph implements Graph, NodeWeights, NodeProperties, Relations
 
     @Override
     public double weightOf(final int sourceNodeId, final int targetNodeId) {
-        long relId = container.isBoth
-                ? RawValues.combineSorted(sourceNodeId, targetNodeId)
-                : RawValues.combineIntInt(sourceNodeId, targetNodeId);
-        return relationshipWeights.get(relId);
+        return relationshipWeights.get(sourceNodeId, targetNodeId);
     }
 
     @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
@@ -29,14 +29,10 @@ import org.neo4j.graphalgo.core.GraphDimensions;
 import org.neo4j.graphalgo.core.IdMap;
 import org.neo4j.graphalgo.core.WeightMap;
 import org.neo4j.graphalgo.core.utils.ImportProgress;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.StatementTask;
-import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.impl.api.RelationshipVisitor;
-import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import java.util.function.Supplier;
@@ -44,22 +40,19 @@ import java.util.function.Supplier;
 
 final class RelationshipImporter extends StatementTask<Void, EntityNotFoundException> {
 
-    private final boolean sort;
-    private IdMap idMap;
     private final PrimitiveIntIterable nodes;
+    private final GraphSetup setup;
+    private final ImportProgress progress;
+    private final int[] relationId;
+
+    private final int nodeSize;
+    private final int nodeOffset;
+
+    private IdMap idMap;
+    private AdjacencyMatrix matrix;
     private WeightMapping relWeights;
     private WeightMapping nodeWeights;
     private WeightMapping nodeProps;
-    private final ImportProgress progress;
-    private final int[] relationId;
-    private final boolean loadIncoming;
-    private final boolean loadOutgoing;
-
-    private AdjacencyMatrix matrix;
-    private final int nodeOffset;
-    private int currentNodeCount;
-
-    private int sourceGraphId;
 
     RelationshipImporter(
             GraphDatabaseAPI api,
@@ -69,26 +62,23 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
             int batchSize,
             int nodeOffset,
             IdMap idMap,
+            AdjacencyMatrix matrix,
             PrimitiveIntIterable nodes,
             Supplier<WeightMapping> relWeights,
             Supplier<WeightMapping> nodeWeights,
-            Supplier<WeightMapping> nodeProps,
-            boolean sort) {
+            Supplier<WeightMapping> nodeProps) {
         super(api);
-        int nodeSize = Math.min(batchSize, idMap.size() - nodeOffset);
-        this.progress = progress;
+        this.matrix = matrix;
+        this.nodeSize = Math.min(batchSize, idMap.size() - nodeOffset);
         this.nodeOffset = nodeOffset;
+        this.progress = progress;
         this.idMap = idMap;
         this.nodes = nodes;
+        this.setup = setup;
         this.relWeights = relWeights.get();
         this.nodeWeights = nodeWeights.get();
         this.nodeProps = nodeProps.get();
         this.relationId = dimensions.relationId();
-        loadIncoming = setup.loadIncoming;
-        loadOutgoing = setup.loadOutgoing;
-        this.matrix = new AdjacencyMatrix(nodeSize, loadIncoming, loadOutgoing, setup.sort);
-        this.currentNodeCount = 0;
-        this.sort = sort;
     }
 
     @Override
@@ -96,243 +86,98 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
         return String.format(
                 "[Heavy] RelationshipImport (%d..%d)",
                 nodeOffset,
-                nodeOffset + matrix.capacity());
+                nodeOffset + nodeSize);
     }
 
     @Override
     public Void apply(final Statement statement) throws EntityNotFoundException {
         final ReadOperations readOp = statement.readOperations();
-        final boolean loadIncoming = this.loadIncoming;
-        final boolean loadOutgoing = this.loadOutgoing;
-
-        RelationshipVisitor<EntityNotFoundException> visitOutgoing = null;
-        RelationshipVisitor<EntityNotFoundException> visitIncoming = null;
-        boolean shouldLoadWeights = relWeights instanceof WeightMap;
-        boolean isBoth = loadIncoming && loadOutgoing;
-        if (loadOutgoing) {
-            if (shouldLoadWeights) {
-                final WeightMap weights = (WeightMap) this.relWeights;
-                visitOutgoing = ((relationshipId, typeId, startNodeId, endNodeId) ->
-                        visitOutgoingWithWeight(
-                                readOp,
-                                isBoth,
-                                sourceGraphId,
-                                weights,
-                                relationshipId,
-                                endNodeId));
-            } else {
-                visitOutgoing = ((relationshipId, typeId, startNodeId, endNodeId) -> visitOutgoing(endNodeId));
-            }
-        }
-        if (loadIncoming) {
-            if (shouldLoadWeights) {
-                final WeightMap weights = (WeightMap) this.relWeights;
-                visitIncoming = ((relationshipId, typeId, startNodeId, endNodeId) ->
-                        visitIncomingWithWeight(
-                                readOp,
-                                isBoth,
-                                sourceGraphId,
-                                weights,
-                                relationshipId,
-                                startNodeId));
-            } else {
-                visitIncoming = ((relationshipId, typeId, startNodeId, endNodeId) -> visitIncoming(startNodeId));
-            }
-        }
-
+        final RelationshipLoader loader = prepare(readOp);
         PrimitiveIntIterator iterator = nodes.iterator();
-        int nodeOffset = this.nodeOffset;
-        int nodeCount = 0;
         while (iterator.hasNext()) {
             final int nodeId = iterator.next();
             final long sourceNodeId = idMap.toOriginalNodeId(nodeId);
-            this.sourceGraphId = nodeId - nodeOffset;
-            nodeCount++;
-            readNode(
-                    readOp,
-                    sourceNodeId,
-                    sourceGraphId,
-                    matrix,
-                    loadIncoming,
-                    loadOutgoing,
-                    visitOutgoing,
-                    visitIncoming,
-                    nodeWeights,
-                    nodeProps,
-                    relationId
-            );
+            loader.load(sourceNodeId, nodeId);
             progress.relProgress();
         }
-        this.currentNodeCount = nodeCount;
         return null;
     }
 
-    private void readNode(
-            ReadOperations readOp,
-            long sourceNodeId,
-            int localNodeId,
-            AdjacencyMatrix matrix,
-            boolean loadIncoming,
-            boolean loadOutgoing,
-            RelationshipVisitor<EntityNotFoundException> visitOutgoing,
-            RelationshipVisitor<EntityNotFoundException> visitIncoming,
-            WeightMapping nodeWeights,
-            WeightMapping nodeProps,
-            int[] relationType) throws EntityNotFoundException {
+    private RelationshipLoader prepare(final ReadOperations readOp) {
+        final RelationshipLoader loader;
+        if (setup.loadAsUndirected) {
+            loader = prepareUndirected(readOp);
+        } else {
+            loader = prepareDirected(readOp);
+        }
+
+        if (this.nodeWeights instanceof WeightMap) {
+            WeightMap nodeWeights = (WeightMap) this.nodeWeights;
+
+            if (this.nodeProps instanceof WeightMap) {
+                WeightMap nodeProps = (WeightMap) this.nodeProps;
+                return new ReadWithNodeWeightsAndProps(loader, nodeWeights, nodeProps);
+            }
+            return new ReadWithNodeWeights(loader, nodeWeights);
+        }
+        if (this.nodeProps instanceof WeightMap) {
+            WeightMap nodeProps = (WeightMap) this.nodeProps;
+            return new ReadWithNodeWeights(loader, nodeProps);
+        }
+
+        return loader;
+    }
+
+    private RelationshipLoader prepareDirected(final ReadOperations readOp) {
+        final boolean loadIncoming = setup.loadIncoming;
+        final boolean loadOutgoing = setup.loadOutgoing;
+        final boolean sort = setup.sort;
+        final boolean shouldLoadWeights = relWeights instanceof WeightMap;
+
+        RelationshipLoader loader = null;
         if (loadOutgoing) {
-            readOutgoing(readOp, visitOutgoing, sourceNodeId, localNodeId, matrix, relationType);
+            final VisitRelationship visitor;
+            if (shouldLoadWeights) {
+                visitor = new VisitOutgoingWithWeight(readOp, idMap, sort, (WeightMap) this.relWeights);
+            } else {
+                visitor = new VisitOutgoingNoWeight(idMap, sort);
+            }
+            loader = new ReadOutgoing(readOp, matrix, relationId, visitor);
         }
         if (loadIncoming) {
-            readIncoming(readOp, visitIncoming, sourceNodeId, localNodeId, matrix, relationType);
-        }
-        if (nodeWeights instanceof WeightMap) {
-            final WeightMap weights = (WeightMap) nodeWeights;
-            readNodeWeight(readOp, sourceNodeId, localNodeId, weights, weights.propertyId());
-        }
-        if (nodeProps instanceof WeightMap) {
-            final WeightMap weights = (WeightMap) nodeProps;
-            readNodeWeight(readOp, sourceNodeId, localNodeId, weights, weights.propertyId());
-        }
-    }
-
-    private void readOutgoing(
-            ReadOperations readOp,
-            RelationshipVisitor<EntityNotFoundException> visit,
-            long sourceNodeId,
-            int localNodeId,
-            AdjacencyMatrix matrix,
-            int[] relationType) throws EntityNotFoundException {
-        final int outDegree;
-        final RelationshipIterator rels;
-        if (relationType == null) {
-            outDegree = readOp.nodeGetDegree(sourceNodeId, Direction.OUTGOING);
-            rels = readOp.nodeGetRelationships(sourceNodeId, Direction.OUTGOING);
-        } else {
-            outDegree = readOp.nodeGetDegree(sourceNodeId, Direction.OUTGOING, relationType[0]);
-            rels = readOp.nodeGetRelationships(sourceNodeId, Direction.OUTGOING, relationType);
-        }
-
-        matrix.armOut(localNodeId, outDegree);
-        while (rels.hasNext()) {
-            final long relId = rels.next();
-            rels.relationshipVisit(relId, visit);
-        }
-        if (sort) {
-            matrix.sortOutgoing(localNodeId);
-        }
-    }
-
-    private void readIncoming(
-            ReadOperations readOp,
-            RelationshipVisitor<EntityNotFoundException> visit,
-            long sourceNodeId,
-            int localNodeId,
-            AdjacencyMatrix matrix,
-            int[] relationType) throws EntityNotFoundException {
-        final int outDegree;
-        final RelationshipIterator rels;
-        if (relationType == null) {
-            outDegree = readOp.nodeGetDegree(sourceNodeId, Direction.INCOMING);
-            rels = readOp.nodeGetRelationships(sourceNodeId, Direction.INCOMING);
-        } else {
-            outDegree = readOp.nodeGetDegree(sourceNodeId, Direction.INCOMING, relationType[0]);
-            rels = readOp.nodeGetRelationships(sourceNodeId, Direction.INCOMING, relationType);
-        }
-
-        matrix.armIn(localNodeId, outDegree);
-        while (rels.hasNext()) {
-            final long relId = rels.next();
-            rels.relationshipVisit(relId, visit);
-        }
-        if (sort) {
-            matrix.sortIncoming(localNodeId);
-        }
-    }
-
-    private void readNodeWeight(
-            ReadOperations readOp,
-            long sourceNodeId,
-            int sourceGraphId,
-            WeightMap weights,
-            int propertyId)  {
-        try {
-            Object value = readOp.nodeGetProperty(sourceNodeId, propertyId);
-            if (value != null) {
-                weights.set(sourceGraphId, value);
+            final VisitRelationship visitor;
+            if (shouldLoadWeights) {
+                visitor = new VisitIncomingWithWeight(readOp, idMap, sort, (WeightMap) this.relWeights);
+            } else {
+                visitor = new VisitIncomingNoWeight(idMap, sort);
             }
-        } catch (EntityNotFoundException ignored) {
+            if (loader != null) {
+                ReadOutgoing readOutgoing = (ReadOutgoing) loader;
+                loader = new ReadBoth(readOutgoing, visitor);
+            } else {
+                loader = new ReadIncoming(readOp, matrix, relationId, visitor);
+            }
         }
+        if (loader == null) {
+            loader = new ReadNothing(readOp, matrix, relationId);
+        }
+        return loader;
     }
 
-    private int visitOutgoing(long endNodeId) {
-        final int targetGraphId = idMap.get(endNodeId);
-        if (targetGraphId != -1) {
-            matrix.addOutgoing(sourceGraphId, targetGraphId);
+    private RelationshipLoader prepareUndirected(final ReadOperations readOp) {
+        final VisitRelationship visitorIn;
+        final VisitRelationship visitorOut;
+        if (relWeights instanceof WeightMap) {
+            visitorIn = new VisitIncomingWithWeight(readOp, idMap, true, (WeightMap) this.relWeights);
+            visitorOut = new VisitOutgoingWithWeight(readOp, idMap, true, (WeightMap) this.relWeights);
+        } else {
+            visitorIn = new VisitIncomingNoWeight(idMap, true);
+            visitorOut = new VisitOutgoingNoWeight(idMap, true);
         }
-        return targetGraphId;
+        return new ReadUndirected(readOp, matrix, relationId, visitorOut, visitorIn);
     }
 
-    private int visitOutgoingWithWeight(
-            ReadOperations readOp,
-            boolean isBoth,
-            int sourceGraphId,
-            WeightMap weights,
-            long relationshipId,
-            long endNodeId) throws EntityNotFoundException {
-        final int targetGraphId = visitOutgoing(endNodeId);
-        if (targetGraphId != -1) {
-            visitWeight(readOp, isBoth, sourceGraphId, targetGraphId, weights, relationshipId);
-        }
-        return targetGraphId;
-    }
-
-    private int visitIncoming(long startNodeId) {
-        final int startGraphId = idMap.get(startNodeId);
-        if (startGraphId != -1) {
-            matrix.addIncoming(startGraphId, sourceGraphId);
-        }
-        return startGraphId;
-    }
-
-    private int visitIncomingWithWeight(
-            ReadOperations readOp,
-            boolean isBoth,
-            int sourceGraphId,
-            WeightMap weights,
-            long relationshipId,
-            long startNodeId) throws EntityNotFoundException {
-        final int targetGraphId = visitIncoming(startNodeId);
-        if (targetGraphId != -1) {
-            visitWeight(readOp, isBoth, sourceGraphId, targetGraphId, weights, relationshipId);
-        }
-        return targetGraphId;
-    }
-
-    private void visitWeight(
-            ReadOperations readOp,
-            boolean isBoth,
-            int sourceGraphId,
-            int targetGraphId,
-            WeightMap weights,
-            long relationshipId) throws EntityNotFoundException {
-        Object value = readOp.relationshipGetProperty(relationshipId, weights.propertyId());
-        if (value == null) {
-            return;
-        }
-        double defaultValue = weights.defaultValue();
-        double doubleValue = RawValues.extractValue(value, defaultValue);
-        if (Double.compare(doubleValue, defaultValue) == 0) {
-            return;
-        }
-
-        long relId = isBoth
-                ? RawValues.combineSorted(sourceGraphId, targetGraphId)
-                : RawValues.combineIntInt(sourceGraphId, targetGraphId);
-
-        weights.put(relId, doubleValue);
-    }
-
-    Graph toGraph(final IdMap idMap) {
+    Graph toGraph(final IdMap idMap, final AdjacencyMatrix matrix) {
         return new HeavyGraph(
                 idMap,
                 matrix,
@@ -342,14 +187,12 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
     }
 
     void writeInto(
-            AdjacencyMatrix matrix,
             WeightMapping relWeights,
             WeightMapping nodeWeights,
             WeightMapping nodeProps) {
-        matrix.addMatrix(this.matrix, nodeOffset, currentNodeCount);
-        combineMaps(relWeights, this.relWeights, nodeOffset);
-        combineMaps(nodeWeights, this.nodeWeights, nodeOffset);
-        combineMaps(nodeProps, this.nodeProps, nodeOffset);
+        combineMaps(relWeights, this.relWeights);
+        combineMaps(nodeWeights, this.nodeWeights);
+        combineMaps(nodeProps, this.nodeProps);
     }
 
     void release() {
@@ -360,7 +203,7 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
         this.nodeProps = null;
     }
 
-    private void combineMaps(WeightMapping global, WeightMapping local, int offset) {
+    private void combineMaps(WeightMapping global, WeightMapping local) {
         if (global instanceof WeightMap && local instanceof WeightMap) {
             WeightMap localWeights = (WeightMap) local;
             final LongDoubleMap localMap = localWeights.weights();
@@ -368,7 +211,7 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
             final LongDoubleMap globalMap = globalWeights.weights();
 
             for (LongDoubleCursor cursor : localMap) {
-                globalMap.put(cursor.key + offset, cursor.value);
+                globalMap.put(cursor.key, cursor.value);
             }
         }
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
@@ -168,8 +168,8 @@ final class RelationshipImporter extends StatementTask<Void, EntityNotFoundExcep
         final VisitRelationship visitorIn;
         final VisitRelationship visitorOut;
         if (relWeights instanceof WeightMap) {
-            visitorIn = new VisitIncomingWithWeight(readOp, idMap, true, (WeightMap) this.relWeights);
-            visitorOut = new VisitOutgoingWithWeight(readOp, idMap, true, (WeightMap) this.relWeights);
+            visitorIn = new VisitIncomingNoWeight(idMap, true);
+            visitorOut = new VisitUndirectedOutgoingWithWeight(readOp, idMap, true, (WeightMap) this.relWeights);
         } else {
             visitorIn = new VisitIncomingNoWeight(idMap, true);
             visitorOut = new VisitOutgoingNoWeight(idMap, true);

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipLoader.java
@@ -1,0 +1,245 @@
+package org.neo4j.graphalgo.core.heavyweight;
+
+import org.neo4j.graphalgo.core.WeightMap;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+
+abstract class RelationshipLoader {
+    private final ReadOperations readOp;
+    private final AdjacencyMatrix matrix;
+    private final int[] relationType;
+
+    RelationshipLoader(
+            final ReadOperations readOp,
+            final AdjacencyMatrix matrix,
+            final int[] relationType) {
+        this.readOp = readOp;
+        this.matrix = matrix;
+        this.relationType = relationType;
+    }
+
+    RelationshipLoader(final RelationshipLoader other) {
+        this.readOp = other.readOp;
+        this.matrix = other.matrix;
+        this.relationType = other.relationType;
+    }
+
+    abstract void load(long sourceNodeId, int localNodeId) throws EntityNotFoundException;
+
+    void readOutgoing(
+            VisitRelationship visit,
+            long sourceNodeId,
+            int localNodeId) throws EntityNotFoundException {
+        final int outDegree = degree(sourceNodeId, Direction.OUTGOING);
+        if (outDegree > 0) {
+            final RelationshipIterator rels = rels(sourceNodeId, Direction.OUTGOING);
+            final int[] targets = matrix.armOut(localNodeId, outDegree);
+            visit.prepareNextNode(localNodeId, targets);
+            while (rels.hasNext()) {
+                final long relId = rels.next();
+                rels.relationshipVisit(relId, visit);
+            }
+            matrix.setOutDegree(localNodeId, visit.flush());
+        }
+    }
+
+    void readIncoming(
+            VisitRelationship visit,
+            long sourceNodeId,
+            int localNodeId) throws EntityNotFoundException {
+        final int inDegree = degree(sourceNodeId, Direction.INCOMING);
+        if (inDegree > 0) {
+            final RelationshipIterator rels = rels(sourceNodeId, Direction.INCOMING);
+            final int[] targets = matrix.armIn(localNodeId, inDegree);
+            visit.prepareNextNode(localNodeId, targets);
+            while (rels.hasNext()) {
+                final long relId = rels.next();
+                rels.relationshipVisit(relId, visit);
+            }
+            matrix.setInDegree(localNodeId, visit.flush());
+        }
+    }
+
+    void readUndirected(
+            VisitRelationship visitOut,
+            VisitRelationship visitIn,
+            long sourceNodeId,
+            int localNodeId) throws EntityNotFoundException {
+        final int degree = degree(sourceNodeId, Direction.BOTH);
+        if (degree > 0) {
+            final int[] targets = matrix.armOut(localNodeId, degree);
+            visitIn.prepareNextNode(localNodeId, targets);
+            RelationshipIterator rels = rels(sourceNodeId, Direction.INCOMING);
+            while (rels.hasNext()) {
+                final long relId = rels.next();
+                rels.relationshipVisit(relId, visitIn);
+            }
+            visitOut.prepareNextNode(visitIn);
+            rels = rels(sourceNodeId, Direction.OUTGOING);
+            while (rels.hasNext()) {
+                final long relId = rels.next();
+                rels.relationshipVisit(relId, visitOut);
+            }
+            matrix.setOutDegree(localNodeId, visitOut.flush());
+        }
+    }
+
+    void readNodeWeight(
+            long sourceNodeId,
+            int sourceGraphId,
+            WeightMap weights,
+            int propertyId) {
+        try {
+            Object value = readOp.nodeGetProperty(sourceNodeId, propertyId);
+            if (value != null) {
+                weights.set(sourceGraphId, value);
+            }
+        } catch (EntityNotFoundException ignored) {
+        }
+    }
+
+    private int degree(long nodeId, Direction direction) throws EntityNotFoundException {
+        if (relationType == null) {
+            return readOp.nodeGetDegree(nodeId, direction);
+        }
+        return readOp.nodeGetDegree(nodeId, direction, relationType[0]);
+    }
+
+    private RelationshipIterator rels(long nodeId, Direction direction) throws EntityNotFoundException {
+        if (relationType == null) {
+            return readOp.nodeGetRelationships(nodeId, direction);
+        }
+        return readOp.nodeGetRelationships(nodeId, direction, relationType);
+    }
+}
+
+final class ReadNothing extends RelationshipLoader {
+    ReadNothing(
+            final ReadOperations readOp,
+            final AdjacencyMatrix matrix,
+            final int[] relationType) {
+        super(readOp, matrix, relationType);
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) {
+    }
+}
+
+final class ReadOutgoing extends RelationshipLoader {
+    final VisitRelationship visitOutgoing;
+
+    ReadOutgoing(
+            final ReadOperations readOp,
+            final AdjacencyMatrix matrix,
+            final int[] relationType,
+            final VisitRelationship visitOutgoing) {
+        super(readOp, matrix, relationType);
+        this.visitOutgoing = visitOutgoing;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        readOutgoing(visitOutgoing, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadIncoming extends RelationshipLoader {
+    private final VisitRelationship visitIncoming;
+
+    ReadIncoming(
+            final ReadOperations readOp,
+            final AdjacencyMatrix matrix,
+            final int[] relationType,
+            final VisitRelationship visitIncoming) {
+        super(readOp, matrix, relationType);
+        this.visitIncoming = visitIncoming;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        readIncoming(visitIncoming, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadBoth extends RelationshipLoader {
+    private final VisitRelationship visitOutgoing;
+    private final VisitRelationship visitIncoming;
+
+    ReadBoth(final ReadOutgoing readOut, final VisitRelationship visitIncoming) {
+        super(readOut);
+        this.visitOutgoing = readOut.visitOutgoing;
+        this.visitIncoming = visitIncoming;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        readOutgoing(visitOutgoing, sourceNodeId, localNodeId);
+        readIncoming(visitIncoming, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadUndirected extends RelationshipLoader {
+    private final VisitRelationship visitOutgoing;
+    private final VisitRelationship visitIncoming;
+
+    ReadUndirected(
+            final ReadOperations readOp,
+            final AdjacencyMatrix matrix,
+            final int[] relationType,
+            final VisitRelationship visitOutgoing,
+            final VisitRelationship visitIncoming) {
+        super(readOp, matrix, relationType);
+        this.visitOutgoing = visitOutgoing;
+        this.visitIncoming = visitIncoming;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        readUndirected(visitOutgoing, visitIncoming, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadWithNodeWeights extends RelationshipLoader {
+    private final RelationshipLoader loader;
+    private final WeightMap nodeWeights;
+
+    ReadWithNodeWeights(
+            final RelationshipLoader loader,
+            final WeightMap nodeWeights) {
+        super(loader);
+        this.loader = loader;
+        this.nodeWeights = nodeWeights;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        loader.load(sourceNodeId, localNodeId);
+        readNodeWeight(sourceNodeId, localNodeId, nodeWeights, nodeWeights.propertyId());
+    }
+}
+
+final class ReadWithNodeWeightsAndProps extends RelationshipLoader {
+    private final RelationshipLoader loader;
+    private final WeightMap nodeWeights;
+    private final WeightMap nodeProps;
+
+    ReadWithNodeWeightsAndProps(
+            final RelationshipLoader loader,
+            final WeightMap nodeWeights,
+            final WeightMap nodeProps) {
+        super(loader);
+        this.loader = loader;
+        this.nodeWeights = nodeWeights;
+        this.nodeProps = nodeProps;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final int localNodeId) throws EntityNotFoundException {
+        loader.load(sourceNodeId, localNodeId);
+        readNodeWeight(sourceNodeId, localNodeId, nodeWeights, nodeWeights.propertyId());
+        readNodeWeight(sourceNodeId, localNodeId, nodeProps, nodeProps.propertyId());
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/VisitRelationship.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/VisitRelationship.java
@@ -1,0 +1,195 @@
+package org.neo4j.graphalgo.core.heavyweight;
+
+import org.neo4j.graphalgo.core.IdMap;
+import org.neo4j.graphalgo.core.WeightMap;
+import org.neo4j.graphalgo.core.utils.RawValues;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+
+import java.util.Arrays;
+
+
+abstract class VisitRelationship implements RelationshipVisitor<EntityNotFoundException> {
+
+    private final IdMap idMap;
+    private final boolean shouldSort;
+
+    private int[] targets;
+    private int length;
+    private long prevNode;
+    private boolean isSorted;
+
+    int prevTarget;
+    int sourceGraphId;
+
+    VisitRelationship(final IdMap idMap, final boolean shouldSort) {
+        this.idMap = idMap;
+        this.shouldSort = shouldSort;
+        if (!shouldSort) {
+            isSorted = false;
+        }
+    }
+
+    final void prepareNextNode(final int sourceGraphId, final int[] targets) {
+        this.sourceGraphId = sourceGraphId;
+        length = 0;
+        prevTarget = -1;
+        prevNode = -1L;
+        isSorted = shouldSort;
+        this.targets = targets;
+    }
+
+    final void prepareNextNode(VisitRelationship other) {
+        this.sourceGraphId = other.sourceGraphId;
+        length = other.length;
+        prevTarget = other.prevTarget;
+        prevNode = other.prevNode;
+        isSorted = other.isSorted;
+        targets = other.targets;
+    }
+
+    final boolean addNode(final long nodeId) {
+        if (nodeId == prevNode) {
+            return false;
+        }
+        final int targetId = idMap.get(nodeId);
+        if (targetId == -1) {
+            return false;
+        }
+        if (isSorted && targetId < prevTarget) {
+            isSorted = false;
+        }
+        targets[length++] = targetId;
+        prevNode = nodeId;
+        prevTarget = targetId;
+        return true;
+    }
+
+    final int flush() {
+        if (shouldSort) {
+            Arrays.sort(targets, 0, length);
+            length = checkDistinct(targets, length);
+        }
+        return length;
+    }
+
+    static void visitWeight(
+            ReadOperations readOp,
+            int sourceGraphId,
+            int targetGraphId,
+            WeightMap weights,
+            long relationshipId) {
+        Object value;
+        try {
+            value = readOp.relationshipGetProperty(relationshipId, weights.propertyId());
+        } catch (EntityNotFoundException ignored) {
+            return;
+        }
+        if (value == null) {
+            return;
+        }
+        double defaultValue = weights.defaultValue();
+        double doubleValue = RawValues.extractValue(value, defaultValue);
+        if (Double.compare(doubleValue, defaultValue) == 0) {
+            return;
+        }
+        long relId = RawValues.combineIntInt(sourceGraphId, targetGraphId);
+        weights.put(relId, doubleValue);
+    }
+
+    private static int checkDistinct(final int[] values, final int len) {
+        int prev = -1;
+        for (int i = 0; i < len; i++) {
+            final int value = values[i];
+            if (value == prev) {
+                return distinct(values, i, len);
+            }
+            prev = value;
+        }
+        return len;
+    }
+
+    private static int distinct(final int[] values, final int start, final int len) {
+        int prev = values[start - 1];
+        int write = start;
+        for (int i = start + 1; i < len; i++) {
+            final int value = values[i];
+            if (value > prev) {
+                values[write++] = value;
+            }
+            prev = value;
+        }
+        return write;
+    }
+}
+
+final class VisitOutgoingNoWeight extends VisitRelationship {
+
+    VisitOutgoingNoWeight(final IdMap idMap, final boolean shouldSort) {
+        super(idMap, shouldSort);
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        addNode(endNodeId);
+    }
+}
+
+final class VisitIncomingNoWeight extends VisitRelationship {
+
+    VisitIncomingNoWeight(final IdMap idMap, final boolean shouldSort) {
+        super(idMap, shouldSort);
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        addNode(startNodeId);
+    }
+}
+
+final class VisitOutgoingWithWeight extends VisitRelationship {
+
+    private final ReadOperations readOp;
+    private final WeightMap weights;
+
+    VisitOutgoingWithWeight(
+            final ReadOperations readOp,
+            final IdMap idMap,
+            final boolean shouldSort,
+            final WeightMap weights) {
+        super(idMap, shouldSort);
+        this.readOp = readOp;
+        this.weights = weights;
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        if (addNode(endNodeId)) {
+            visitWeight(readOp, sourceGraphId, prevTarget, weights, relationshipId);
+        }
+    }
+}
+
+final class VisitIncomingWithWeight extends VisitRelationship {
+
+    private final ReadOperations readOp;
+    private final WeightMap weights;
+
+    VisitIncomingWithWeight(
+            final ReadOperations readOp,
+            final IdMap idMap,
+            final boolean shouldSort,
+            final WeightMap weights) {
+        super(idMap, shouldSort);
+        this.readOp = readOp;
+        this.weights = weights;
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        if (addNode(startNodeId)) {
+            visitWeight(readOp, prevTarget, sourceGraphId, weights, relationshipId);
+        }
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphFactory.java
@@ -18,7 +18,6 @@
  */
 package org.neo4j.graphalgo.core.huge;
 
-import org.apache.lucene.util.ArrayUtil;
 import org.neo4j.graphalgo.api.GraphFactory;
 import org.neo4j.graphalgo.api.GraphSetup;
 import org.neo4j.graphalgo.api.HugeGraph;
@@ -27,19 +26,14 @@ import org.neo4j.graphalgo.core.GraphDimensions;
 import org.neo4j.graphalgo.core.HugeWeightMap;
 import org.neo4j.graphalgo.core.utils.ImportProgress;
 import org.neo4j.graphalgo.core.utils.ParallelUtil;
-import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.StatementTask;
 import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
 import org.neo4j.graphalgo.core.utils.paged.ByteArray;
-import org.neo4j.graphalgo.core.utils.paged.DeltaEncoding;
 import org.neo4j.graphalgo.core.utils.paged.LongArray;
-import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.impl.api.RelationshipVisitor;
-import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import java.util.Arrays;
@@ -47,9 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public final class HugeGraphFactory extends GraphFactory {
 
-    public HugeGraphFactory(
-            GraphDatabaseAPI api,
-            GraphSetup setup) {
+    public HugeGraphFactory(GraphDatabaseAPI api, GraphSetup setup) {
         super(api, setup);
     }
 
@@ -188,11 +180,6 @@ public final class HugeGraphFactory extends GraphFactory {
         );
     }
 
-    @FunctionalInterface
-    private interface RelationshipLoader {
-        void apply(long neoId, long nodeId) throws EntityNotFoundException;
-    }
-
     private static final class NodeQueue {
         private final AtomicLong current = new AtomicLong();
         private final long max;
@@ -258,6 +245,8 @@ public final class HugeGraphFactory extends GraphFactory {
         @Override
         public Void apply(final Statement statement) throws EntityNotFoundException {
             ReadOperations readOp = statement.readOperations();
+            boolean shouldLoadWeights = weightId >= 0;
+            HugeWeightMap weightMap = shouldLoadWeights ? (HugeWeightMap) weights : null;
 
             final RelationshipLoader loader;
             if (undirected) {
@@ -265,328 +254,56 @@ public final class HugeGraphFactory extends GraphFactory {
                 assert outAllocator != null;
 
                 outAllocator.prepare();
-                RelationshipDeltaEncoding importer = newImporter(readOp, Direction.BOTH);
-                loader = (neo, node) -> readUndirectedRelationships(
-                        node,
-                        neo,
-                        readOp,
-                        outOffsets,
-                        outAllocator,
-                        importer
-                );
+                final VisitRelationship visitIn;
+                final VisitRelationship visitOut;
+                if (shouldLoadWeights) {
+                    visitIn = new VisitIncomingNoWeight(idMap);
+                    visitOut = new VisitUndirectedOutgoingWithWeight(readOp, idMap, weightMap, weightId);
+                } else {
+                    visitIn = new VisitIncomingNoWeight(idMap);
+                    visitOut = new VisitOutgoingNoWeight(idMap);
+                }
+                loader = new ReadUndirected(readOp, outOffsets, outAllocator, relationId, visitOut, visitIn);
             } else {
-
+                RelationshipLoader load = null;
+                if (outAllocator != null) {
+                    outAllocator.prepare();
+                    final VisitRelationship visitOut;
+                    if (shouldLoadWeights) {
+                        visitOut = new VisitOutgoingWithWeight(readOp, idMap, weightMap, weightId);
+                    } else {
+                        visitOut = new VisitOutgoingNoWeight(idMap);
+                    }
+                    load = new ReadOutgoing(readOp, outOffsets, outAllocator, relationId, visitOut);
+                }
                 if (inAllocator != null) {
                     inAllocator.prepare();
-                    RelationshipDeltaEncoding inImporter = newImporter(readOp, Direction.INCOMING);
-                    if (outAllocator != null) {
-                        outAllocator.prepare();
-                        RelationshipDeltaEncoding outImporter = newImporter(readOp, Direction.OUTGOING);
-                        loader = (neo, node) -> {
-                            readRelationships(
-                                    node,
-                                    neo,
-                                    readOp,
-                                    Direction.OUTGOING,
-                                    outOffsets,
-                                    outAllocator,
-                                    outImporter
-                            );
-                            readRelationships(
-                                    node,
-                                    neo,
-                                    readOp,
-                                    Direction.INCOMING,
-                                    inOffsets,
-                                    inAllocator,
-                                    inImporter
-                            );
-                        };
+                    final VisitRelationship visitIn;
+                    if (shouldLoadWeights) {
+                        visitIn = new VisitIncomingWithWeight(readOp, idMap, weightMap, weightId);
                     } else {
-                        loader = (neo, node) -> readRelationships(
-                                node,
-                                neo,
-                                readOp,
-                                Direction.INCOMING,
-                                inOffsets,
-                                inAllocator,
-                                inImporter
-                        );
+                        visitIn = new VisitIncomingNoWeight(idMap);
                     }
+                    if (load != null) {
+                        load = new ReadBoth((ReadOutgoing) load, visitIn, inOffsets, inAllocator);
+                    } else {
+                        load = new ReadIncoming(readOp, inOffsets, inAllocator, relationId, visitIn);
+                    }
+                }
+                if (load != null) {
+                    loader = load;
                 } else {
-                    if (outAllocator != null) {
-                        outAllocator.prepare();
-                        RelationshipDeltaEncoding outImporter = newImporter(readOp, Direction.OUTGOING);
-                        loader = (neo, node) -> readRelationships(
-                                node,
-                                neo,
-                                readOp,
-                                Direction.OUTGOING,
-                                outOffsets,
-                                outAllocator,
-                                outImporter
-                        );
-                    } else {
-                        loader = (neo, node) -> {
-                        };
-                    }
+                    loader = new ReadNothing(readOp, relationId);
                 }
             }
 
             NodeQueue nodes = this.nodes;
             long nodeId;
             while ((nodeId = nodes.next()) != -1L) {
-                loader.apply(idMap.toOriginalNodeId(nodeId), nodeId);
+                loader.load(idMap.toOriginalNodeId(nodeId), nodeId);
                 progress.relProgress();
             }
             return null;
-        }
-
-        private RelationshipDeltaEncoding newImporter(
-                ReadOperations readOp,
-                Direction direction) {
-            if (weightId >= 0) {
-                return new RelationshipDeltaEncodingWithWeights(
-                        idMap,
-                        direction,
-                        readOp,
-                        weightId,
-                        weights);
-            }
-            return new RelationshipDeltaEncoding(idMap, direction);
-        }
-
-        private void readRelationships(
-                long sourceGraphId,
-                long sourceNodeId,
-                ReadOperations readOp,
-                Direction direction,
-                LongArray offsets,
-                ByteArray.LocalAllocator allocator,
-                RelationshipDeltaEncoding delta) throws EntityNotFoundException {
-
-            int degree = degree(sourceNodeId, readOp, direction);
-            if (degree <= 0) {
-                return;
-            }
-
-            RelationshipIterator rs = relationships(sourceNodeId, readOp, direction);
-            delta.reset(degree, sourceGraphId);
-            while (rs.hasNext()) {
-                rs.relationshipVisit(rs.next(), delta);
-            }
-
-            long requiredSize = delta.applyDelta();
-            degree = delta.length;
-            if (degree == 0) {
-                return;
-            }
-
-            long adjacencyIdx = allocator.allocate(requiredSize);
-            offsets.set(sourceGraphId, adjacencyIdx);
-
-            ByteArray.BulkAdder bulkAdder = allocator.adder;
-            bulkAdder.addUnsignedInt(degree);
-            long[] targets = delta.targets;
-            for (int i = 0; i < degree; i++) {
-                bulkAdder.addVLong(targets[i]);
-            }
-        }
-
-        private void readUndirectedRelationships(
-                long sourceGraphId,
-                long sourceNodeId,
-                ReadOperations readOp,
-                LongArray offsets,
-                ByteArray.LocalAllocator allocator,
-                RelationshipDeltaEncoding delta) throws EntityNotFoundException {
-
-            int degree = degree(sourceNodeId, readOp, Direction.BOTH);
-            if (degree > 0) {
-                delta.reset(degree, sourceGraphId);
-                delta.setDirection(Direction.INCOMING);
-                RelationshipIterator rs = relationships(sourceNodeId, readOp, Direction.INCOMING);
-                while (rs.hasNext()) {
-                    rs.relationshipVisit(rs.next(), delta);
-                }
-                delta.setDirection(Direction.OUTGOING);
-                rs = relationships(sourceNodeId, readOp, Direction.OUTGOING);
-                while (rs.hasNext()) {
-                    rs.relationshipVisit(rs.next(), delta);
-                }
-
-                long requiredSize = delta.applyDelta();
-                degree = delta.length;
-                long adjacencyIdx = allocator.allocate(requiredSize);
-                offsets.set(sourceGraphId, adjacencyIdx);
-
-                ByteArray.BulkAdder bulkAdder = allocator.adder;
-                bulkAdder.addUnsignedInt(degree);
-                long[] targets = delta.targets;
-                for (int i = 0; i < degree; i++) {
-                    bulkAdder.addVLong(targets[i]);
-                }
-            }
-        }
-
-        private int degree(
-                long sourceNodeId,
-                ReadOperations readOp,
-                Direction direction) throws EntityNotFoundException {
-            return relationId == null
-                    ? readOp.nodeGetDegree(sourceNodeId, direction)
-                    : readOp.nodeGetDegree(sourceNodeId, direction, relationId[0]);
-        }
-
-        private RelationshipIterator relationships(
-                long sourceNodeId,
-                ReadOperations readOp,
-                Direction direction) throws EntityNotFoundException {
-            return relationId == null
-                    ? readOp.nodeGetRelationships(sourceNodeId, direction)
-                    : readOp.nodeGetRelationships(sourceNodeId, direction, relationId);
-        }
-    }
-
-    private static class RelationshipDeltaEncoding implements RelationshipVisitor<EntityNotFoundException> {
-
-        private final HugeIdMap idMap;
-        Direction direction;
-
-        private long prevTarget;
-        private long prevNode;
-        private boolean isSorted;
-
-        int length;
-        long sourceGraphId;
-        long[] targets;
-
-        RelationshipDeltaEncoding(
-                HugeIdMap idMap,
-                Direction direction) {
-            this.idMap = idMap;
-            this.direction = direction;
-            targets = new long[0];
-        }
-
-        final void reset(int degree, long sourceGraphId) {
-            this.sourceGraphId = sourceGraphId;
-            length = 0;
-            prevTarget = -1L;
-            prevNode = -1L;
-            isSorted = true;
-            if (targets.length < degree) {
-                targets = new long[ArrayUtil.oversize(degree, Long.BYTES)];
-            }
-        }
-
-        final void setDirection(Direction direction) {
-            this.direction = direction;
-        }
-
-        @Override
-        public final void visit(
-                final long relationshipId,
-                final int typeId,
-                final long startNodeId,
-                final long endNodeId) throws EntityNotFoundException {
-            maybeVisit(
-                    relationshipId,
-                    direction == Direction.OUTGOING ? endNodeId : startNodeId);
-        }
-
-        long maybeVisit(
-                final long relationshipId,
-                final long endNodeId) throws EntityNotFoundException {
-            if (endNodeId == prevNode) {
-                return prevTarget;
-            }
-            long targetId = idMap.toHugeMappedNodeId(endNodeId);
-            if (targetId == -1L) {
-                return -1L;
-            }
-
-            if (isSorted && targetId < prevTarget) {
-                isSorted = false;
-            }
-            targets[length++] = targetId;
-            prevNode = endNodeId;
-            prevTarget = targetId;
-            return targetId;
-        }
-
-        final long applyDelta() {
-            int length = this.length;
-            if (length == 0) {
-                return 0L;
-            }
-
-            long[] targets = this.targets;
-            if (!isSorted) {
-                Arrays.sort(targets, 0, length);
-            }
-
-            long delta = targets[0];
-            int writePos = 1;
-            long requiredBytes = 4L + DeltaEncoding.vSize(delta);  // length as full-int
-
-            for (int i = 1; i < length; ++i) {
-                long nextDelta = targets[i];
-                long value = targets[writePos] = nextDelta - delta;
-                if (value > 0L) {
-                    ++writePos;
-                    requiredBytes += DeltaEncoding.vSize(value);
-                    delta = nextDelta;
-                }
-            }
-
-            this.length = writePos;
-            return requiredBytes;
-        }
-    }
-
-    private static final class RelationshipDeltaEncodingWithWeights extends RelationshipDeltaEncoding {
-        private final int weightId;
-        private final HugeWeightMap weights;
-        private final ReadOperations readOp;
-        private final double defaultValue;
-
-        RelationshipDeltaEncodingWithWeights(
-                final HugeIdMap idMap,
-                final Direction direction,
-                final ReadOperations readOp,
-                int weightId,
-                HugeWeightMapping weights) {
-            super(idMap, direction);
-            this.readOp = readOp;
-            if (!(weights instanceof HugeWeightMap) || weightId < 0) {
-                throw new IllegalArgumentException(
-                        "expected weights to be defined");
-            }
-            this.weightId = weightId;
-            this.weights = (HugeWeightMap) weights;
-            defaultValue = this.weights.defaultValue();
-        }
-
-        @Override
-        long maybeVisit(
-                final long relationshipId,
-                final long endNodeId) throws EntityNotFoundException {
-            long targetGraphId = super.maybeVisit(relationshipId, endNodeId);
-            if (targetGraphId >= 0) {
-                Object value = readOp.relationshipGetProperty(
-                        relationshipId,
-                        weightId);
-                double doubleVal = RawValues.extractValue(value, defaultValue);
-                if (Double.compare(doubleVal, defaultValue) != 0) {
-                    if (direction == Direction.OUTGOING) {
-                        weights.put(sourceGraphId, targetGraphId, value);
-                    } else {
-                        weights.put(targetGraphId, sourceGraphId, value);
-                    }
-                }
-            }
-            return targetGraphId;
         }
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/HugeGraphImpl.java
@@ -90,7 +90,6 @@ public class HugeGraphImpl implements HugeGraph {
     private ByteArray.DeltaCursor empty;
     private ByteArray.DeltaCursor inCache;
     private ByteArray.DeltaCursor outCache;
-    private final boolean isBoth;
     private boolean canRelease = true;
 
     HugeGraphImpl(
@@ -111,7 +110,6 @@ public class HugeGraphImpl implements HugeGraph {
         inCache = newCursor(this.inAdjacency);
         outCache = newCursor(this.outAdjacency);
         empty = inCache == null ? newCursor(this.outAdjacency) : newCursor(this.inAdjacency);
-        isBoth = inAdjacency != null && outAdjacency != null;
     }
 
     @Override
@@ -136,41 +134,11 @@ public class HugeGraphImpl implements HugeGraph {
 
     @Override
     public double weightOf(final long sourceNodeId, final long targetNodeId) {
-        if (isBoth && sourceNodeId > targetNodeId) {
-            return weights.weight(targetNodeId, sourceNodeId);
-        }
         return weights.weight(sourceNodeId, targetNodeId);
     }
 
     @Override
-    public void forEachRelationship(
-            long vertexId,
-            Direction direction,
-            HugeRelationshipConsumer consumer) {
-        switch (direction) {
-            case INCOMING:
-                forEachIncoming(vertexId, consumer);
-                return;
-
-            case OUTGOING:
-                forEachOutgoing(vertexId, consumer);
-                return;
-
-            case BOTH:
-                forEachIncoming(vertexId, consumer);
-                forEachOutgoing(vertexId, consumer);
-                return;
-
-            default:
-                throw new IllegalArgumentException(direction + "");
-        }
-    }
-
-    @Override
-    public void forEachRelationship(
-            int nodeId,
-            Direction direction,
-            RelationshipConsumer consumer) {
+    public void forEachRelationship(long nodeId, Direction direction, HugeRelationshipConsumer consumer) {
         switch (direction) {
             case INCOMING:
                 forEachIncoming(nodeId, consumer);
@@ -181,8 +149,8 @@ public class HugeGraphImpl implements HugeGraph {
                 return;
 
             case BOTH:
-                forEachIncoming(nodeId, consumer);
                 forEachOutgoing(nodeId, consumer);
+                forEachIncoming(nodeId, consumer);
                 return;
 
             default:
@@ -191,19 +159,45 @@ public class HugeGraphImpl implements HugeGraph {
     }
 
     @Override
-    public void forEachRelationship(
-            int nodeId,
-            Direction direction,
-            WeightedRelationshipConsumer consumer) {
-        RelationshipConsumer nonWeighted = (s, t, relId) -> {
-            double weight = weightOf((long) s, (long) t);
-            return consumer.accept(
-                    s,
-                    t,
-                    RawValues.combineIntInt(direction, s, t),
-                    weight);
-        };
-        forEachRelationship(nodeId, direction, nonWeighted);
+    public void forEachRelationship(int nodeId, Direction direction, RelationshipConsumer consumer) {
+        switch (direction) {
+            case INCOMING:
+                forEachIncoming(nodeId, consumer);
+                return;
+
+            case OUTGOING:
+                forEachOutgoing(nodeId, consumer);
+                return;
+
+            case BOTH:
+                forEachOutgoing(nodeId, consumer);
+                forEachIncoming(nodeId, consumer);
+                return;
+
+            default:
+                throw new IllegalArgumentException(direction + "");
+        }
+    }
+
+    @Override
+    public void forEachRelationship(int nodeId, Direction direction, WeightedRelationshipConsumer consumer) {
+        switch (direction) {
+            case INCOMING:
+                forEachIncoming(nodeId, consumer);
+                return;
+
+            case OUTGOING:
+                forEachOutgoing(nodeId, consumer);
+                return;
+
+            case BOTH:
+                forEachOutgoing(nodeId, consumer);
+                forEachIncoming(nodeId, consumer);
+                return;
+
+            default:
+                throw new IllegalArgumentException(direction + "");
+        }
     }
 
     @Override
@@ -234,8 +228,8 @@ public class HugeGraphImpl implements HugeGraph {
     }
 
     @Override
-    public long toOriginalNodeId(long vertexId) {
-        return idMapping.toOriginalNodeId(vertexId);
+    public long toOriginalNodeId(long nodeId) {
+        return idMapping.toOriginalNodeId(nodeId);
     }
 
     @Override
@@ -244,55 +238,41 @@ public class HugeGraphImpl implements HugeGraph {
     }
 
     @Override
-    public void forEachIncoming(
-            final long node,
-            final HugeRelationshipConsumer consumer) {
-        ByteArray.DeltaCursor cursor = cursor(
-                node,
-                inCache,
-                inOffsets,
-                inAdjacency);
-        consumeNodes(node, cursor, consumer);
+    public void forEachIncoming(long node, final HugeRelationshipConsumer consumer) {
+        forEachIncoming(node, inCache, consumer);
     }
 
     @Override
     public void forEachIncoming(int nodeId, RelationshipConsumer consumer) {
-        final long node = (long) nodeId;
-        ByteArray.DeltaCursor cursor = cursor(
-                node,
-                inAdjacency.newCursor(),
-                inOffsets,
-                inAdjacency);
-        consumeNodes(node, cursor, (s, t) -> consumer.accept(
-                (int) s,
-                (int) t,
-                RawValues.combineIntInt((int) t, (int) s)));
+        forEachIncoming((long) nodeId, inAdjacency.newCursor(), toHugeInConsumer(consumer));
     }
 
-    @Override
-    public void forEachOutgoing(
-            final long node,
-            final HugeRelationshipConsumer consumer) {
-        ByteArray.DeltaCursor cursor = cursor(
-                node,
-                outCache,
-                outOffsets,
-                outAdjacency);
+    public void forEachIncoming(int nodeId, WeightedRelationshipConsumer consumer) {
+        forEachIncoming((long) nodeId, inAdjacency.newCursor(), toHugeInConsumer(consumer));
+    }
+
+    private void forEachIncoming(long node, ByteArray.DeltaCursor newCursor, final HugeRelationshipConsumer consumer) {
+        ByteArray.DeltaCursor cursor = cursor(node, newCursor, inOffsets, inAdjacency);
         consumeNodes(node, cursor, consumer);
     }
 
     @Override
+    public void forEachOutgoing(long node, final HugeRelationshipConsumer consumer) {
+        forEachOutgoing(node, outCache, consumer);
+    }
+
+    @Override
     public void forEachOutgoing(int nodeId, RelationshipConsumer consumer) {
-        final long node = (long) nodeId;
-        ByteArray.DeltaCursor cursor = cursor(
-                node,
-                outAdjacency.newCursor(),
-                outOffsets,
-                outAdjacency);
-        consumeNodes(node, cursor, (s, t) -> consumer.accept(
-                (int) s,
-                (int) t,
-                RawValues.combineIntInt((int) s, (int) t)));
+        forEachOutgoing((long) nodeId, outAdjacency.newCursor(), toHugeOutConsumer(consumer));
+    }
+
+    public void forEachOutgoing(int nodeId, WeightedRelationshipConsumer consumer) {
+        forEachOutgoing((long) nodeId, outAdjacency.newCursor(), toHugeOutConsumer(consumer));
+    }
+
+    private void forEachOutgoing(long node, ByteArray.DeltaCursor newCursor, final HugeRelationshipConsumer consumer) {
+        ByteArray.DeltaCursor cursor = cursor(node, newCursor, outOffsets, outAdjacency);
+        consumeNodes(node, cursor, consumer);
     }
 
     @Override
@@ -311,67 +291,6 @@ public class HugeGraphImpl implements HugeGraph {
     @Override
     public HugeRelationshipIntersect intersectionCopy() {
         return new HugeGraphIntersectImpl(outAdjacency, outOffsets);
-    }
-
-    private ByteArray.DeltaCursor newCursor(final ByteArray adjacency) {
-        return adjacency != null ? adjacency.newCursor() : null;
-    }
-
-    private int degree(long node, LongArray offsets, ByteArray array) {
-        long offset = offsets.get(node);
-        if (offset == 0L) {
-            return 0;
-        }
-        return array.getInt(offset);
-    }
-
-    private ByteArray.DeltaCursor cursor(
-            long node,
-            ByteArray.DeltaCursor reuse,
-            LongArray offsets,
-            ByteArray array) {
-        final long offset = offsets.get(node);
-        if (offset == 0L) {
-            return empty;
-        }
-        return array.deltaCursor(reuse, offset);
-    }
-
-    private void consumeNodes(
-            long startNode,
-            ByteArray.DeltaCursor cursor,
-            HugeRelationshipConsumer consumer) {
-        //noinspection StatementWithEmptyBody
-        while (cursor.hasNextVLong() && consumer.accept(startNode, cursor.nextVLong()));
-    }
-
-    @Override
-    public void release() {
-        if (!canRelease) return;
-        if (inAdjacency != null) {
-            tracker.remove(inAdjacency.release());
-            tracker.remove(inOffsets.release());
-            inAdjacency = null;
-            inOffsets = null;
-        }
-        if (outAdjacency != null) {
-            tracker.remove(outAdjacency.release());
-            tracker.remove(outOffsets.release());
-            outAdjacency = null;
-            outOffsets = null;
-        }
-        if (weights != null) {
-            tracker.remove(weights.release());
-        }
-        empty = null;
-        inCache = null;
-        outCache = null;
-        weights = null;
-    }
-
-    @Override
-    public void canRelease(boolean canRelease) {
-        this.canRelease = canRelease;
     }
 
     /**
@@ -412,5 +331,102 @@ public class HugeGraphImpl implements HugeGraph {
     @Override
     public boolean exists(int sourceNodeId, int targetNodeId, Direction direction) {
         return exists((long) sourceNodeId, (long) targetNodeId, direction);
+    }
+
+    @Override
+    public void canRelease(boolean canRelease) {
+        this.canRelease = canRelease;
+    }
+
+    @Override
+    public void release() {
+        if (!canRelease) return;
+        if (inAdjacency != null) {
+            tracker.remove(inAdjacency.release());
+            tracker.remove(inOffsets.release());
+            inAdjacency = null;
+            inOffsets = null;
+        }
+        if (outAdjacency != null) {
+            tracker.remove(outAdjacency.release());
+            tracker.remove(outOffsets.release());
+            outAdjacency = null;
+            outOffsets = null;
+        }
+        if (weights != null) {
+            tracker.remove(weights.release());
+        }
+        empty = null;
+        inCache = null;
+        outCache = null;
+        weights = null;
+    }
+
+    private ByteArray.DeltaCursor newCursor(final ByteArray adjacency) {
+        return adjacency != null ? adjacency.newCursor() : null;
+    }
+
+    private int degree(long node, LongArray offsets, ByteArray array) {
+        long offset = offsets.get(node);
+        if (offset == 0L) {
+            return 0;
+        }
+        return array.getInt(offset);
+    }
+
+    private ByteArray.DeltaCursor cursor(
+            long node,
+            ByteArray.DeltaCursor reuse,
+            LongArray offsets,
+            ByteArray array) {
+        final long offset = offsets.get(node);
+        if (offset == 0L) {
+            return empty;
+        }
+        return array.deltaCursor(reuse, offset);
+    }
+
+    private void consumeNodes(
+            long startNode,
+            ByteArray.DeltaCursor cursor,
+            HugeRelationshipConsumer consumer) {
+        //noinspection StatementWithEmptyBody
+        while (cursor.hasNextVLong() && consumer.accept(startNode, cursor.nextVLong()));
+    }
+
+    private HugeRelationshipConsumer toHugeOutConsumer(RelationshipConsumer consumer) {
+        return (s, t) -> consumer.accept(
+                (int) s,
+                (int) t,
+                RawValues.combineIntInt((int) s, (int) t));
+    }
+
+    private HugeRelationshipConsumer toHugeInConsumer(RelationshipConsumer consumer) {
+        return (s, t) -> consumer.accept(
+                (int) s,
+                (int) t,
+                RawValues.combineIntInt((int) t, (int) s));
+    }
+
+    private HugeRelationshipConsumer toHugeOutConsumer(WeightedRelationshipConsumer consumer) {
+        return (s, t) -> {
+            double weight = weightOf(s, t);
+            return consumer.accept(
+                    (int) s,
+                    (int) t,
+                    RawValues.combineIntInt((int) s, (int) t),
+                    weight);
+        };
+    }
+
+    private HugeRelationshipConsumer toHugeInConsumer(WeightedRelationshipConsumer consumer) {
+        return (s, t) -> {
+            double weight = weightOf(t, s);
+            return consumer.accept(
+                    (int) s,
+                    (int) t,
+                    RawValues.combineIntInt((int) t, (int) s),
+                    weight);
+        };
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/RelationshipLoader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/RelationshipLoader.java
@@ -1,0 +1,209 @@
+package org.neo4j.graphalgo.core.huge;
+
+import org.neo4j.graphalgo.core.utils.paged.ByteArray;
+import org.neo4j.graphalgo.core.utils.paged.LongArray;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+
+abstract class RelationshipLoader {
+    private final ReadOperations readOp;
+    private final int[] relationType;
+
+    RelationshipLoader(
+            final ReadOperations readOp,
+            final int[] relationType) {
+        this.readOp = readOp;
+        this.relationType = relationType;
+    }
+
+    RelationshipLoader(final RelationshipLoader other) {
+        this.readOp = other.readOp;
+        this.relationType = other.relationType;
+    }
+
+    abstract void load(long sourceNodeId, long localNodeId) throws EntityNotFoundException;
+
+    void readRelationship(
+            VisitRelationship visit,
+            LongArray offsets,
+            ByteArray.LocalAllocator allocator,
+            Direction direction,
+            long sourceNodeId,
+            long localGraphId)
+    throws EntityNotFoundException {
+
+        int degree = degree(sourceNodeId, direction);
+        if (degree <= 0) {
+            return;
+        }
+
+        RelationshipIterator rs = rels(sourceNodeId, direction);
+        visit.prepareNextNode(degree, localGraphId);
+        while (rs.hasNext()) {
+            rs.relationshipVisit(rs.next(), visit);
+        }
+        long adjacencyIdx = visit.flush(allocator);
+        if (adjacencyIdx != 0L) {
+            offsets.set(localGraphId, adjacencyIdx);
+        }
+    }
+
+    void readUndirected(
+            VisitRelationship visitOut,
+            VisitRelationship visitIn,
+            LongArray offsets,
+            ByteArray.LocalAllocator allocator,
+            long sourceNodeId,
+            long localGraphId)
+    throws EntityNotFoundException {
+
+        int degree = degree(sourceNodeId, Direction.BOTH);
+        if (degree <= 0) {
+            return;
+        }
+
+        RelationshipIterator rs = rels(sourceNodeId, Direction.INCOMING);
+        visitIn.prepareNextNode(degree, localGraphId);
+        while (rs.hasNext()) {
+            rs.relationshipVisit(rs.next(), visitIn);
+        }
+
+        visitOut.prepareNextNode(visitIn);
+        rs = rels(sourceNodeId, Direction.OUTGOING);
+        while (rs.hasNext()) {
+            rs.relationshipVisit(rs.next(), visitOut);
+        }
+
+        long adjacencyIdx = visitOut.flush(allocator);
+        if (adjacencyIdx != 0L) {
+            offsets.set(localGraphId, adjacencyIdx);
+        }
+    }
+
+    private int degree(long nodeId, Direction direction) throws EntityNotFoundException {
+        if (relationType == null) {
+            return readOp.nodeGetDegree(nodeId, direction);
+        }
+        return readOp.nodeGetDegree(nodeId, direction, relationType[0]);
+    }
+
+    private RelationshipIterator rels(long nodeId, Direction direction) throws EntityNotFoundException {
+        if (relationType == null) {
+            return readOp.nodeGetRelationships(nodeId, direction);
+        }
+        return readOp.nodeGetRelationships(nodeId, direction, relationType);
+    }
+}
+
+final class ReadNothing extends RelationshipLoader {
+    ReadNothing(final ReadOperations readOp, final int[] relationType) {
+        super(readOp, relationType);
+    }
+
+    @Override
+    void load(final long sourceNodeId, final long localNodeId) {
+    }
+}
+
+final class ReadOutgoing extends RelationshipLoader {
+    final VisitRelationship visitOutgoing;
+    final LongArray offsets;
+    final ByteArray.LocalAllocator allocator;
+
+    ReadOutgoing(
+            final ReadOperations readOp,
+            LongArray offsets,
+            ByteArray.LocalAllocator allocator,
+            final int[] relationType,
+            final VisitRelationship visitOutgoing) {
+        super(readOp, relationType);
+        this.offsets = offsets;
+        this.allocator = allocator;
+        this.visitOutgoing = visitOutgoing;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final long localNodeId) throws EntityNotFoundException {
+        readRelationship(visitOutgoing, offsets, allocator, Direction.OUTGOING, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadIncoming extends RelationshipLoader {
+    private final VisitRelationship visitIncoming;
+    private final LongArray offsets;
+    private final ByteArray.LocalAllocator allocator;
+
+    ReadIncoming(
+            final ReadOperations readOp,
+            LongArray offsets,
+            ByteArray.LocalAllocator allocator,
+            final int[] relationType,
+            final VisitRelationship visitIncoming) {
+        super(readOp, relationType);
+        this.offsets = offsets;
+        this.allocator = allocator;
+        this.visitIncoming = visitIncoming;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final long localNodeId) throws EntityNotFoundException {
+        readRelationship(visitIncoming, offsets, allocator, Direction.INCOMING, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadBoth extends RelationshipLoader {
+    private final VisitRelationship visitOutgoing;
+    private final VisitRelationship visitIncoming;
+    private final LongArray inOffsets;
+    private final ByteArray.LocalAllocator inAllocator;
+    private final LongArray outOffsets;
+    private final ByteArray.LocalAllocator outAllocator;
+
+    ReadBoth(
+            final ReadOutgoing readOut,
+            final VisitRelationship visitIncoming,
+            final LongArray inOffsets,
+            final ByteArray.LocalAllocator inAllocator) {
+        super(readOut);
+        this.visitOutgoing = readOut.visitOutgoing;
+        this.visitIncoming = visitIncoming;
+        this.outOffsets = readOut.offsets;
+        this.outAllocator = readOut.allocator;
+        this.inOffsets = inOffsets;
+        this.inAllocator = inAllocator;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final long localNodeId) throws EntityNotFoundException {
+        readRelationship(visitOutgoing, outOffsets, outAllocator, Direction.OUTGOING, sourceNodeId, localNodeId);
+        readRelationship(visitIncoming, inOffsets, inAllocator, Direction.INCOMING, sourceNodeId, localNodeId);
+    }
+}
+
+final class ReadUndirected extends RelationshipLoader {
+    private final VisitRelationship visitOutgoing;
+    private final VisitRelationship visitIncoming;
+    private final LongArray offsets;
+    private final ByteArray.LocalAllocator allocator;
+
+    ReadUndirected(
+            final ReadOperations readOp,
+            LongArray offsets,
+            ByteArray.LocalAllocator allocator,
+            final int[] relationType,
+            final VisitRelationship visitOutgoing,
+            final VisitRelationship visitIncoming) {
+        super(readOp, relationType);
+        this.offsets = offsets;
+        this.allocator = allocator;
+        this.visitOutgoing = visitOutgoing;
+        this.visitIncoming = visitIncoming;
+    }
+
+    @Override
+    void load(final long sourceNodeId, final long localNodeId) throws EntityNotFoundException {
+        readUndirected(visitOutgoing, visitIncoming, offsets, allocator, sourceNodeId, localNodeId);
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/VisitRelationship.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/VisitRelationship.java
@@ -1,0 +1,264 @@
+package org.neo4j.graphalgo.core.huge;
+
+import org.apache.lucene.util.ArrayUtil;
+import org.neo4j.graphalgo.core.HugeWeightMap;
+import org.neo4j.graphalgo.core.utils.RawValues;
+import org.neo4j.graphalgo.core.utils.paged.ByteArray;
+import org.neo4j.graphalgo.core.utils.paged.DeltaEncoding;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+
+import java.util.Arrays;
+
+
+abstract class VisitRelationship implements RelationshipVisitor<EntityNotFoundException> {
+
+    private final HugeIdMap idMap;
+
+    private long[] targets;
+    private int length;
+    private long prevNode;
+    private boolean isSorted;
+
+    long prevTarget;
+    long sourceGraphId;
+
+    VisitRelationship(final HugeIdMap idMap) {
+        this.idMap = idMap;
+        this.targets = new long[0];
+    }
+
+    final void prepareNextNode(int degree, long sourceGraphId) {
+        this.sourceGraphId = sourceGraphId;
+        length = 0;
+        prevTarget = -1L;
+        prevNode = -1L;
+        isSorted = true;
+        if (targets.length < degree) {
+            targets = new long[ArrayUtil.oversize(degree, Long.BYTES)];
+        }
+    }
+
+    final void prepareNextNode(VisitRelationship other) {
+        this.sourceGraphId = other.sourceGraphId;
+        length = other.length;
+        prevTarget = other.prevTarget;
+        prevNode = other.prevNode;
+        isSorted = other.isSorted;
+        targets = other.targets;
+    }
+
+    final boolean addNode(final long nodeId) {
+        if (nodeId == prevNode) {
+            return false;
+        }
+        final long targetId = idMap.toHugeMappedNodeId(nodeId);
+        if (targetId == -1L) {
+            return false;
+        }
+        if (isSorted && targetId < prevTarget) {
+            isSorted = false;
+        }
+        targets[length++] = targetId;
+        prevNode = nodeId;
+        prevTarget = targetId;
+        return true;
+    }
+
+    final long flush(ByteArray.LocalAllocator allocator) {
+        long requiredSize = applyDelta();
+        int degree = length;
+        if (degree == 0) {
+            return 0L;
+        }
+
+        long adjacencyIdx = allocator.allocate(requiredSize);
+        ByteArray.BulkAdder bulkAdder = allocator.adder;
+        bulkAdder.addUnsignedInt(degree);
+        long[] targets = this.targets;
+        for (int i = 0; i < degree; i++) {
+            bulkAdder.addVLong(targets[i]);
+        }
+
+        return adjacencyIdx;
+    }
+
+    static void visitWeight(
+            ReadOperations readOp,
+            long sourceGraphId,
+            long targetGraphId,
+            HugeWeightMap weights,
+            int weightProperty,
+            long relationshipId) {
+        Object value;
+        try {
+            value = readOp.relationshipGetProperty(relationshipId, weightProperty);
+        } catch (EntityNotFoundException ignored) {
+            return;
+        }
+        if (value == null) {
+            return;
+        }
+
+        double defaultValue = weights.defaultValue();
+        double doubleValue = RawValues.extractValue(value, defaultValue);
+        if (Double.compare(doubleValue, defaultValue) == 0) {
+            return;
+        }
+        weights.put(sourceGraphId, targetGraphId, doubleValue);
+    }
+
+    static void visitUndirectedWeight(
+            ReadOperations readOp,
+            long sourceGraphId,
+            long targetGraphId,
+            HugeWeightMap weights,
+            int weightProperty,
+            long relationshipId) {
+        Object value;
+        try {
+            value = readOp.relationshipGetProperty(relationshipId, weightProperty);
+        } catch (EntityNotFoundException ignored) {
+            return;
+        }
+        if (value == null) {
+            return;
+        }
+        double defaultValue = weights.defaultValue();
+        double doubleValue = RawValues.extractValue(value, defaultValue);
+        if (Double.compare(doubleValue, defaultValue) == 0) {
+            return;
+        }
+        weights.put(sourceGraphId, targetGraphId, doubleValue);
+        weights.put(targetGraphId, sourceGraphId, doubleValue);
+    }
+
+    private long applyDelta() {
+        int length = this.length;
+        if (length == 0) {
+            return 0L;
+        }
+
+        long[] targets = this.targets;
+        if (!isSorted) {
+            Arrays.sort(targets, 0, length);
+        }
+
+        long delta = targets[0];
+        int writePos = 1;
+        long requiredBytes = 4L + DeltaEncoding.vSize(delta);  // length as full-int
+
+        for (int i = 1; i < length; ++i) {
+            long nextDelta = targets[i];
+            long value = targets[writePos] = nextDelta - delta;
+            if (value > 0L) {
+                ++writePos;
+                requiredBytes += DeltaEncoding.vSize(value);
+                delta = nextDelta;
+            }
+        }
+
+        this.length = writePos;
+        return requiredBytes;
+    }
+}
+
+final class VisitOutgoingNoWeight extends VisitRelationship {
+
+    VisitOutgoingNoWeight(final HugeIdMap idMap) {
+        super(idMap);
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        addNode(endNodeId);
+    }
+}
+
+final class VisitIncomingNoWeight extends VisitRelationship {
+
+    VisitIncomingNoWeight(final HugeIdMap idMap) {
+        super(idMap);
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        addNode(startNodeId);
+    }
+}
+
+final class VisitOutgoingWithWeight extends VisitRelationship {
+
+    private final ReadOperations readOp;
+    private final HugeWeightMap weights;
+    private final int weightProperty;
+
+    VisitOutgoingWithWeight(
+            final ReadOperations readOp,
+            final HugeIdMap idMap,
+            final HugeWeightMap weights,
+            final int weightProperty) {
+        super(idMap);
+        this.readOp = readOp;
+        this.weights = weights;
+        this.weightProperty = weightProperty;
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        if (addNode(endNodeId)) {
+            visitWeight(readOp, sourceGraphId, prevTarget, weights, weightProperty, relationshipId);
+        }
+    }
+}
+
+final class VisitIncomingWithWeight extends VisitRelationship {
+
+    private final ReadOperations readOp;
+    private final HugeWeightMap weights;
+    private final int weightProperty;
+
+    VisitIncomingWithWeight(
+            final ReadOperations readOp,
+            final HugeIdMap idMap,
+            final HugeWeightMap weights,
+            final int weightProperty) {
+        super(idMap);
+        this.readOp = readOp;
+        this.weights = weights;
+        this.weightProperty = weightProperty;
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        if (addNode(startNodeId)) {
+            visitWeight(readOp, prevTarget, sourceGraphId, weights, weightProperty, relationshipId);
+        }
+    }
+}
+
+final class VisitUndirectedOutgoingWithWeight extends VisitRelationship {
+
+    private final ReadOperations readOp;
+    private final HugeWeightMap weights;
+    private final int weightProperty;
+
+    VisitUndirectedOutgoingWithWeight(
+            final ReadOperations readOp,
+            final HugeIdMap idMap,
+            final HugeWeightMap weights,
+            final int weightProperty) {
+        super(idMap);
+        this.readOp = readOp;
+        this.weights = weights;
+        this.weightProperty = weightProperty;
+    }
+
+    @Override
+    public void visit(final long relationshipId, final int typeId, final long startNodeId, final long endNodeId) {
+        if (addNode(endNodeId)) {
+            visitUndirectedWeight(readOp, sourceGraphId, prevTarget, weights, weightProperty, relationshipId);
+        }
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/lightweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/lightweight/RelationshipImporter.java
@@ -22,6 +22,7 @@ import org.neo4j.graphalgo.api.WeightMapping;
 import org.neo4j.graphalgo.core.IdMap;
 import org.neo4j.graphalgo.core.WeightMap;
 import org.neo4j.graphalgo.core.utils.IdCombiner;
+import org.neo4j.graphalgo.core.utils.RawValues;
 import org.neo4j.graphalgo.core.utils.paged.IntArray;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.api.ReadOperations;
@@ -51,8 +52,7 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
             int[] relationId,
             Direction direction,
             IntArray.BulkAdder bulkAdder,
-            WeightMapping weights,
-            IdCombiner combiner) {
+            WeightMapping weights) {
         if (weights instanceof WeightMap) {
             return new WithWeights(
                     mapping,
@@ -61,7 +61,6 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
                     readOp,
                     direction,
                     (WeightMap) weights,
-                    combiner,
                     bulkAdder);
         } else {
             return new RelationshipImporter(
@@ -159,12 +158,11 @@ class RelationshipImporter implements RelationshipVisitor<EntityNotFoundExceptio
                 ReadOperations readOp,
                 Direction direction,
                 WeightMap weights,
-                IdCombiner combiner,
                 IntArray.BulkAdder bulkAdder) {
             super(readOp, mapping, offsets, relationId, direction, bulkAdder);
             this.weights = weights;
             this.weightId = weights.propertyId();
-            this.idCombiner = combiner;
+            this.idCombiner = RawValues.combiner(direction);
         }
 
         @Override

--- a/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphView.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphView.java
@@ -53,7 +53,6 @@ public class GraphView implements Graph {
     private final ThreadToStatementContextBridge contextBridge;
     private final GraphDatabaseAPI db;
 
-    private final Direction direction;
     private final double propertyDefaultWeight;
     private int relationTypeId;
     private int nodeCount;
@@ -61,17 +60,14 @@ public class GraphView implements Graph {
     private int labelId;
     private final IdMapping idMapping;
 
-    public GraphView(
+    GraphView(
             GraphDatabaseAPI db,
-            Direction direction,
             String label,
             String relation,
             String propertyName,
             double propertyDefaultWeight) {
         this.db = db;
-        contextBridge = db.getDependencyResolver()
-                .resolveDependency(ThreadToStatementContextBridge.class);
-        this.direction = direction;
+        contextBridge = db.getDependencyResolver().resolveDependency(ThreadToStatementContextBridge.class);
         this.propertyDefaultWeight = propertyDefaultWeight;
 
         withinTransaction(read -> {
@@ -139,7 +135,7 @@ public class GraphView implements Graph {
                 };
 
                 if (direction == Direction.BOTH) {
-                    iterate(read, originalNodeId, visitor, Direction.INCOMING, Direction.OUTGOING);
+                    iterate(read, originalNodeId, visitor, Direction.OUTGOING, Direction.INCOMING);
                 } else {
                     iterate(read, originalNodeId, visitor, direction);
                 }
@@ -247,11 +243,7 @@ public class GraphView implements Graph {
 
                     }
                 };
-                if (this.direction == Direction.BOTH) {
-                    iterate(read, sourceId, visitor, Direction.OUTGOING, Direction.INCOMING);
-                } else {
-                    iterate(read, sourceId, visitor, this.direction);
-                }
+                iterate(read, sourceId, visitor, Direction.OUTGOING);
                 return nodeWeight[0];
             });
         } catch (EntityNotFoundException e) {

--- a/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/neo4jview/GraphViewFactory.java
@@ -21,7 +21,6 @@ package org.neo4j.graphalgo.core.neo4jview;
 import org.neo4j.graphalgo.api.Graph;
 import org.neo4j.graphalgo.api.GraphFactory;
 import org.neo4j.graphalgo.api.GraphSetup;
-import org.neo4j.graphdb.Direction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 public final class GraphViewFactory extends GraphFactory {
@@ -34,16 +33,8 @@ public final class GraphViewFactory extends GraphFactory {
 
     @Override
     public Graph build() {
-        final Direction direction;
-        if (setup.loadOutgoing) {
-            direction = setup.loadIncoming ? Direction.BOTH : Direction.OUTGOING;
-        } else {
-            direction = setup.loadIncoming ? Direction.INCOMING : null;
-        }
-
         return new GraphView(
                 api,
-                direction,
                 setup.startLabel,
                 setup.relationshipType,
                 setup.relationWeightPropertyName,

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/RawValues.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/RawValues.java
@@ -28,7 +28,7 @@ import org.neo4j.graphdb.Direction;
 public class RawValues {
 
     public static final IdCombiner OUTGOING = RawValues::combineIntInt;
-    public static final IdCombiner BOTH = RawValues::combineSorted;
+    public static final IdCombiner INCOMING = (h, t) -> RawValues.combineIntInt(t, h);
 
     /**
      * shifts head into the most significant 4 bytes of the long
@@ -42,27 +42,15 @@ public class RawValues {
         return ((long) head << 32) | (long) tail & 0xFFFFFFFFL;
     }
 
-    public static long combineSorted(int head, int tail) {
-        return head <= tail
-                ? combineIntInt(head, tail)
-                : combineIntInt(tail, head);
-    }
-
     public static long combineIntInt(Direction direction, int head, int tail) {
-        switch (direction) {
-            case OUTGOING:
-                return combineIntInt(head, tail);
-            case INCOMING:
-                return combineIntInt(tail, head);
-            case BOTH:
-                return combineSorted(head, tail);
-            default:
-                throw new IllegalArgumentException("Unkown direction: " + direction);
+        if (direction == Direction.INCOMING) {
+            return combineIntInt(tail, head);
         }
+        return combineIntInt(head, tail);
     }
 
     public static IdCombiner combiner(Direction direction) {
-        return (direction == Direction.BOTH) ? BOTH : OUTGOING;
+        return (direction == Direction.INCOMING) ? INCOMING : OUTGOING;
     }
 
     /**

--- a/tests/src/test/java/org/neo4j/graphalgo/core/neo4jview/GraphViewTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/neo4jview/GraphViewTest.java
@@ -35,7 +35,7 @@ public class GraphViewTest extends SimpleGraphTestCase {
 
     @BeforeClass
     public static void setupGraph() {
-        graph = new GraphView((GraphDatabaseAPI) setup.getDb(), Direction.BOTH, LABEL, RELATION, WEIGHT_PROPERTY, 0.0);
+        graph = new GraphView((GraphDatabaseAPI) setup.getDb(), LABEL, RELATION, WEIGHT_PROPERTY, 0.0);
         v0 = 0;
         v1 = 1;
         v2 = 2;

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/ClusteringCoefficientTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/ClusteringCoefficientTest.java
@@ -102,6 +102,7 @@ public class ClusteringCoefficientTest {
                 .withLabel(LABEL)
                 .withoutRelationshipWeights()
                 .withoutNodeWeights()
+                .asUndirected(true)
                 .load(HeavyGraphFactory.class);
     }
 

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/ClusteringCoefficientWikiTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/ClusteringCoefficientWikiTest.java
@@ -84,6 +84,7 @@ public class ClusteringCoefficientWikiTest {
                 .withAnyRelationshipType()
                 .withoutRelationshipWeights()
                 .withoutNodeWeights()
+                .asUndirected(true)
                 .load(HeavyGraphFactory.class);
     }
 

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/PrimTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/PrimTest.java
@@ -27,6 +27,7 @@ import org.neo4j.graphalgo.api.Graph;
 import org.neo4j.graphalgo.api.GraphFactory;
 import org.neo4j.graphalgo.api.RelationshipConsumer;
 import org.neo4j.graphalgo.core.GraphLoader;
+import org.neo4j.graphalgo.core.heavyweight.HeavyGraphFactory;
 import org.neo4j.graphalgo.core.huge.HugeGraphFactory;
 import org.neo4j.graphalgo.impl.spanningTrees.Prim;
 import org.neo4j.graphalgo.impl.spanningTrees.SpanningTree;
@@ -35,8 +36,8 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -95,11 +96,10 @@ public class PrimTest {
 
     @Parameterized.Parameters(name = "{1}")
     public static Collection<Object[]> data() {
-        return Collections.singleton(new Object[]{HugeGraphFactory.class, "Huge"});
-//        return Arrays.asList(
-//                new Object[]{HeavyGraphFactory.class, "Heavy"},
-//                new Object[]{HugeGraphFactory.class, "Huge"}
-//        );
+        return Arrays.asList(
+                new Object[]{HeavyGraphFactory.class, "Heavy"},
+                new Object[]{HugeGraphFactory.class, "Huge"}
+        );
     }
 
 

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/TriangleStreamTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/TriangleStreamTest.java
@@ -67,8 +67,7 @@ public class TriangleStreamTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{HeavyGraphFactory.class, "HeavyGraphFactory"},
-                new Object[]{HugeGraphFactory.class, "HugeGraphFactory"},
-                new Object[]{GraphViewFactory.class, "GraphViewFactory"}
+                new Object[]{HugeGraphFactory.class, "HugeGraphFactory"}
         );
     }
 


### PR DESCRIPTION
Undirected support is enabled by using the `#asUndirected(true)` method on the `GraphLoader`, which implies `sort(true)` as well.
During undirected loading, incoming and outgoing relationships are merged, sorted, deduplicated, and stored as OUTGOING. Every algo that uses an undirected graph should only traverse over OUTGOING, not using BOTH or INCOMING, as the data structures for INCOMING are not created and NPEs are bound to happen.
Weights are stored in either direction, so the algo can ask for a weight from `(A)->(B)` or `(B)->(A)` to get the same weight. This is different from the directed behavior, where weights are normalized to be stored in the OUTGOING direction only (INCOMING weights are reversed).

This is larger than expected; in the end several refactoring ended up being included in this PR:

- revert treating BOTH as undirected (#450)
  - pretending that BOTH is also undirected was trying to be too smart 
  - not only didn't work this correctly, it also introduced a couple of edge cases where the graph were just broken
- implement undirected mode in heavy graph
- fix some bugs for undirected mode in huge graph
  - particular weights on incoming relationships weren't correctly stored in undirected mode
- refactor interface/visitor usage for both heavy and huge
  - anonymous ad-hoc lambda implementations are replaced with proper types
- adapt algos and tests to use the new undirected option.
  