### PR TITLE
Fix SparseLargeArray / HugeIdMapping contains

### DIFF
--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/ClosenessCentralityBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/ClosenessCentralityBenchmark.java
@@ -50,7 +50,7 @@ public class ClosenessCentralityBenchmark {
 
     public static final RelationshipType RELATIONSHIP_TYPE = RelationshipType.withName("TYPE");
 
-    @Param({"LIGHT", "HEAVY", "HUGE"})
+    @Param({"HEAVY", "HUGE"})
     public GraphImpl graph;
 
     @Param({"30"})

--- a/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrayBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrayBenchmark.java
@@ -2,6 +2,8 @@ package org.neo4j.graphalgo.utils;
 
 import org.neo4j.graphalgo.core.utils.paged.LongArray;
 import org.neo4j.graphalgo.core.utils.paged.SparseLongArray;
+import org.neo4j.unsafe.impl.batchimport.cache.DynamicLongArray;
+import org.neo4j.unsafe.impl.batchimport.cache.OffHeapLongArray;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -75,5 +77,37 @@ public class LongArrayBenchmark {
     @Benchmark
     public SparseLongArray _06_sparse_set(LongArrays arrays) {
         return LongArrays.createSparse(arrays.primitive);
+    }
+
+    @Benchmark
+    public long _07_offHeap_get(LongArrays arrays) {
+        final int size = arrays.size;
+        final OffHeapLongArray array = arrays.offHeap;
+        long res = 0;
+        for (int i = 0; i < size; i++) {
+            res += array.get(i);
+        }
+        return res;
+    }
+
+    @Benchmark
+    public OffHeapLongArray _08_offHeap_set(LongArrays arrays) {
+        return LongArrays.createOffHeap(arrays.primitive);
+    }
+
+    @Benchmark
+    public long _09_chunked_get(LongArrays arrays) {
+        final int size = arrays.size;
+        final DynamicLongArray array = arrays.chunked;
+        long res = 0;
+        for (int i = 0; i < size; i++) {
+            res += array.get(i);
+        }
+        return res;
+    }
+
+    @Benchmark
+    public DynamicLongArray _10_chunked_set(LongArrays arrays) {
+        return LongArrays.createChunked(arrays.primitive);
     }
 }

--- a/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrayBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrayBenchmark.java
@@ -1,0 +1,79 @@
+package org.neo4j.graphalgo.utils;
+
+import org.neo4j.graphalgo.core.utils.paged.LongArray;
+import org.neo4j.graphalgo.core.utils.paged.SparseLongArray;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@Threads(1)
+@Fork(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class LongArrayBenchmark {
+
+    @Benchmark
+    public long _01_primitive_get(LongArrays arrays) {
+        final int size = arrays.size;
+        final long[] array = arrays.primitive;
+        long res = 0;
+        for (int i = 0; i < size; i++) {
+            res += array[i];
+        }
+        return res;
+    }
+
+    @Benchmark
+    public long[] _02_primitive_set(LongArrays arrays) {
+        final int size = arrays.size;
+        final long[] array = arrays.primitive;
+        long[] result = new long[size];
+        for (int i = 0; i < size; i++) {
+            if (array[i] >= 0) {
+                result[i] = array[i];
+            }
+        }
+        return result;
+    }
+
+    @Benchmark
+    public long _03_paged_get(LongArrays arrays) {
+        final int size = arrays.size;
+        final LongArray array = arrays.paged;
+        long res = 0;
+        for (int i = 0; i < size; i++) {
+            res += array.get(i);
+        }
+        return res;
+    }
+
+    @Benchmark
+    public LongArray _04_paged_set(LongArrays arrays) {
+        return LongArrays.createPaged(arrays.primitive);
+    }
+
+    @Benchmark
+    public long _05_sparse_get(LongArrays arrays) {
+        final int size = arrays.size;
+        final SparseLongArray array = arrays.sparse;
+        long res = 0;
+        for (int i = 0; i < size; i++) {
+            res += array.get(i);
+        }
+        return res;
+    }
+
+    @Benchmark
+    public SparseLongArray _06_sparse_set(LongArrays arrays) {
+        return LongArrays.createSparse(arrays.primitive);
+    }
+}

--- a/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrays.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/utils/LongArrays.java
@@ -1,0 +1,96 @@
+package org.neo4j.graphalgo.utils;
+
+import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
+import org.neo4j.graphalgo.core.utils.paged.LongArray;
+import org.neo4j.graphalgo.core.utils.paged.SparseLongArray;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Arrays;
+import java.util.Random;
+
+@State(Scope.Benchmark)
+public class LongArrays {
+
+    public enum Distribution {
+        uniform, packed;
+    }
+
+    @Param({"100000", "10000000"})
+    int size;
+
+    @Param({"0.1", "0.5", "0.9", "0.999"})
+    double sparseness;
+
+    @Param({"uniform", "packed"})
+    Distribution distribution;
+
+    long[] primitive;
+    LongArray paged;
+    SparseLongArray sparse;
+
+    @Setup
+    public void setup() {
+        primitive = createPrimitive(size, sparseness, distribution);
+        paged = createPaged(primitive);
+        sparse = createSparse(primitive);
+    }
+
+    private static long[] createPrimitive(
+            int size,
+            double sparseness,
+            Distribution distribution) {
+        Random rand = new Random(0);
+        long[] array = new long[size];
+        if (distribution == Distribution.packed) {
+            int blockSize = (int) Math.round(size * (1.0 - sparseness));
+            int maxIndex = size - blockSize;
+            int startIndex = rand.nextInt(maxIndex);
+            Arrays.fill(array, -1L);
+            for (int i = 0; i < blockSize; i++) {
+                array[i + startIndex] = randomLong(rand);
+            }
+        } else {
+            for (int i = 0; i < size; ++i) {
+                if (rand.nextDouble() >= sparseness) {
+                    array[i] = randomLong(rand);
+                } else {
+                    array[i] = -1L;
+                }
+            }
+        }
+        return array;
+    }
+
+    static LongArray createPaged(long[] values) {
+        final LongArray array = LongArray.newArray(values.length, AllocationTracker.EMPTY);
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i];
+            if (value >= 0) {
+                array.set(i, value);
+            }
+        }
+        return array;
+    }
+
+    static SparseLongArray createSparse(long[] values) {
+        final SparseLongArray array = SparseLongArray.newArray(values.length, AllocationTracker.EMPTY);
+        for (int i = 0; i < values.length; i++) {
+            long value = values[i];
+            if (value >= 0) {
+                array.set(i, value);
+            }
+        }
+        return array;
+    }
+
+    private static long randomLong(Random random) {
+        long v;
+        do {
+            v = random.nextLong();
+        } while (v < 0);
+        return v;
+    }
+}

--- a/benchmark/src/main/java/org/neo4j/prof/Heap.java
+++ b/benchmark/src/main/java/org/neo4j/prof/Heap.java
@@ -1,0 +1,47 @@
+package org.neo4j.prof;
+
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.Defaults;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ScalarResult;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public final class Heap implements InternalProfiler {
+
+    private long before;
+
+    @Override
+    public void beforeIteration(final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {
+        before = usedHeap();
+    }
+
+    @Override
+    public Collection<? extends Result> afterIteration(
+            final BenchmarkParams benchmarkParams,
+            final IterationParams iterationParams,
+            final IterationResult result) {
+        long allUsage = usedHeap() - before;
+        long ops = result.getMetadata().getAllOps();
+        double perOpUsage = (double) allUsage / ops;
+
+        return Collections.singletonList(
+                new ScalarResult(Defaults.PREFIX + "heap.alloc.norm", perOpUsage, "B/op", AggregationPolicy.AVG)
+        );
+    }
+
+    @Override
+    public String getDescription() {
+        return "Simple, naive Heap consumption during benchmark. For more detailed profiling, use gc profiler.";
+    }
+
+    private static long usedHeap() {
+        Runtime runtime = Runtime.getRuntime();
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+}

--- a/benchmark/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedHeapFactory.java
+++ b/benchmark/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedHeapFactory.java
@@ -1,0 +1,11 @@
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+public abstract class ChunkedHeapFactory {
+    private static final NumberArrayFactory FACTORY = new ChunkedNumberArrayFactory(NumberArrayFactory.HEAP);
+
+    private ChunkedHeapFactory() {}
+
+    public static DynamicLongArray newArray(int size, long defaultValue) {
+        return (DynamicLongArray) FACTORY.newLongArray(size, defaultValue);
+    }
+}

--- a/benchmark/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/benchmark/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,1 +1,2 @@
 org.neo4j.prof.JFR
+org.neo4j.prof.Heap

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -160,6 +160,7 @@
                     <maxMemory>1g</maxMemory>
                     <parallelism>1</parallelism>
                     <printSummary>true</printSummary>
+                    <jvmArgs>-ea</jvmArgs>
 
                     <listeners>
                         <report-text showThrowable="true" showStackTraces="true" showOutput="always" showStatusOk="true"

--- a/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.fail;
 public final class SparseLongArrayTest extends RandomizedTest {
 
     private static final int PS = PageUtil.pageSizeFor(Long.BYTES);
-    private static final MethodHandle PAGES = PrivateLookup.field(SparseLongArray.class, Object[].class, "pages");
+    private static final MethodHandle PAGES = PrivateLookup.field(SparseLongArray.class, long[][].class, "pages");
 
     @Test
     public void shouldSetAndGet() {

--- a/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
@@ -36,12 +36,15 @@ public final class SparseLongArrayTest extends RandomizedTest {
     }
 
     // capacity check is only an assert
-    @Test(expected = AssertionError.class)
+    @Test
     public void shouldUseCapacityInPageSizedChunks() {
         SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
         // larger than the desired size, but still within a single page
-        array.set(between(PS, 2 * PS - 1), 1337);
-        fail("should have failed out of capacity");
+        try {
+            array.set(between(PS, 2 * PS - 1), 1337);
+            fail("should have failed out of capacity");
+        } catch (AssertionError | ArrayIndexOutOfBoundsException ignore) {
+        }
     }
 
     @Test

--- a/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/utils/paged/SparseLongArrayTest.java
@@ -1,0 +1,132 @@
+package org.neo4j.graphalgo.core.utils.paged;
+
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import org.junit.Test;
+import org.neo4j.graphalgo.serialize.PrivateLookup;
+
+import java.lang.invoke.MethodHandle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public final class SparseLongArrayTest extends RandomizedTest {
+
+    private static final int PS = PageUtil.pageSizeFor(Long.BYTES);
+    private static final MethodHandle PAGES = PrivateLookup.field(SparseLongArray.class, Object[].class, "pages");
+
+    @Test
+    public void shouldSetAndGet() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        int index = between(2, 8);
+        int value = between(42, 1337);
+        array.set(index, value);
+        assertEquals(value, array.get(index));
+    }
+
+    @Test
+    public void shouldSetValuesInPageSizedChunks() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        // larger than the desired size, but still within a single page
+        array.set(between(11, PS -1), 1337);
+        // doesn't fail - good
+    }
+
+    // capacity check is only an assert
+    @Test(expected = AssertionError.class)
+    public void shouldUseCapacityInPageSizedChunks() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        // larger than the desired size, but still within a single page
+        array.set(between(PS, 2 * PS - 1), 1337);
+        fail("should have failed out of capacity");
+    }
+
+    @Test
+    public void shouldHaveContains() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        int index = between(2, 8);
+        int value = between(42, 1337);
+        array.set(index, value);
+        for (int i = 0; i < 10; i++) {
+            if (i == index) {
+                assertTrue("Expected index " + i + " to be contained, but it was not", array.contains(i));
+            } else {
+                assertFalse("Expected index " + i + " not to be contained, but it actually was", array.contains(i));
+            }
+        }
+    }
+
+    @Test
+    public void shouldReturnNegativeOneForMissingValues() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        int index = between(2, 8);
+        int value = between(42, 1337);
+        array.set(index, value);
+        for (int i = 0; i < 10; i++) {
+            boolean expectedContains = i == index;
+            long actual = array.get(i);
+            String message = expectedContains
+                    ? "Expected value at index " + i + " to be set to " + value + ", but got " + actual + " instead"
+                    : "Expected value at index " + i + " to be missing (-1), but got " + actual + " instead";
+            assertEquals(message, expectedContains ? value : -1L, actual);
+        }
+    }
+
+    @Test
+    public void shouldReturnNegativeOneForOutOfRangeValues() {
+        SparseLongArray array = SparseLongArray.newArray(10, AllocationTracker.EMPTY);
+        array.set(between(2, 8), between(42, 1337));
+        assertEquals(-1L, array.get(between(100, 200)));
+    }
+
+    @Test
+    public void shouldReturnNegativeOneForUnsetPages() {
+        SparseLongArray array = SparseLongArray.newArray(PS + 10, AllocationTracker.EMPTY);
+        array.set(5000, between(42, 1337));
+        assertEquals(-1L, array.get(between(100, 200)));
+    }
+
+    @Test
+    public void shouldNotCreateAnyPagesOnInitialization() throws Throwable {
+        AllocationTracker tracker = AllocationTracker.create();
+        SparseLongArray array = SparseLongArray.newArray(2 * PS, tracker);
+
+        final long[][] pages = getPages(array);
+        for (long[] page : pages) {
+            assertNull(page);
+        }
+
+        long tracked = tracker.tracked();
+        // allow some bytes for the container type and
+        assertEquals(50.0, tracked, 50.0);
+    }
+
+    @Test
+    public void shouldCreateAndTrackSparsePagesOnDemand() throws Throwable {
+        AllocationTracker tracker = AllocationTracker.create();
+        SparseLongArray array = SparseLongArray.newArray(2 * PS, tracker);
+
+        int index = between(PS, 2 * PS - 1);
+        int value = between(42, 1337);
+        array.set(index, value);
+
+        final long[][] pages = getPages(array);
+        for (int i = 0; i < pages.length; i++) {
+            if (i == 1) {
+                assertNotNull(pages[i]);
+            } else {
+                assertNull(pages[i]);
+            }
+        }
+
+        long tracked = tracker.tracked();
+        assertEquals(PS * Long.BYTES, tracked, 200.0);
+    }
+
+    private static long[][] getPages(SparseLongArray array) throws Throwable {
+        return (long[][]) PAGES.invoke(array);
+    }
+}


### PR DESCRIPTION
A bug in the SparseLongArray (#392) would falsely report a node to be existing when it was actually skipped during loading. The bug would only manifest, if a user would load the graph using `huge` and a label limitation and where some of the nodes containing the label would be connected to nodes that don't have that particular label. Heavy and cypher loading was not affected.
I changed to implementation and added some tests and benchmarks for the SparseLongArray. All in all, the new implementation is much faster in reads, which prompts me to apply similar changes to the regular `LongArray`, which we're using in quite some places.
![sparselongarray improvements](https://user-images.githubusercontent.com/633183/36104018-282eacce-1011-11e8-8700-4d6dacbd5e09.png)

I also compared the different possible LongArray implementations against the primitive long[] baseline as well as against some arrays from the batch importer.

![sparselongarray comparison](https://user-images.githubusercontent.com/633183/36104365-1863f1c2-1012-11e8-8cd3-5d78152f2d1b.png)
