### PR TITLE
Fixing SSSP/D for cases where a node is queued multiple times before being traversed.

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/impl/AllShortestPaths.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/AllShortestPaths.java
@@ -174,7 +174,7 @@ public class AllShortestPaths extends MSBFSASPAlgorithm<AllShortestPaths> {
                             final double targetDistance = weight + sourceDistance;
                             if (targetDistance < distance[target]) {
                                 distance[target] = targetDistance;
-                                queue.add(target, targetDistance);
+                                queue.set(target, targetDistance);
                             }
                             return true;
                         });

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/ShortestPaths.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/ShortestPaths.java
@@ -99,7 +99,7 @@ public class ShortestPaths extends Algorithm<ShortestPaths> {
                         final double targetCosts = this.costs.getOrDefault(target, Double.POSITIVE_INFINITY);
                         if (weight + sourceCosts < targetCosts) {
                             costs.put(target, weight + sourceCosts);
-                            queue.add(target, targetCosts);
+                            queue.set(target, targetCosts);
                         }
                         return true;
                     });

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/queue/SharedIntPriorityQueue.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/queue/SharedIntPriorityQueue.java
@@ -57,7 +57,13 @@ public abstract class SharedIntPriorityQueue extends IntPriorityQueue {
     }
 
     @Override
-    protected void addCost(final int element, final double cost) {
+    protected boolean addCost(final int element, final double cost) {
+        // does nothing, costs should be managed outside of this queue
+        return false;
+    }
+
+    @Override
+    protected void removeCost(final int element) {
         // does nothing, costs should be managed outside of this queue
     }
 

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/traverse/SimpleBitSet.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/traverse/SimpleBitSet.java
@@ -186,7 +186,9 @@ public class SimpleBitSet extends StampedLock implements PrimitiveIntIterable
 
     private void ensureCapacity( int arrayIndex )
     {
-        data = Arrays.copyOf( data, findNewLength( arrayIndex, data.length ) );
+        if (data.length <= arrayIndex) {
+            data = Arrays.copyOf( data, findNewLength( arrayIndex, data.length ) );
+        }
     }
 
     //

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/ShortestPathIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/ShortestPathIntegrationTest.java
@@ -18,22 +18,25 @@
  */
 package org.neo4j.graphalgo.algo;
 
-import org.junit.AfterClass;
+import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.graphalgo.ShortestPathProc;
-import org.neo4j.graphalgo.TestDatabaseCreator;
 import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.proc.Procedures;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.graphalgo.TestDatabaseCreator;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
@@ -47,12 +50,11 @@ import static org.mockito.Mockito.verify;
 @RunWith(Parameterized.class)
 public class ShortestPathIntegrationTest {
 
-    private static GraphDatabaseAPI db;
+    @ClassRule
+    public static final ImpermanentDatabaseRule DB = new ImpermanentDatabaseRule();
 
-    @AfterClass
-    public static void tearDown() throws Exception {
-        if (db != null) db.shutdown();
-    }
+    @Rule
+    public final ImpermanentDatabaseRule db_599 = new ImpermanentDatabaseRule().startLazily();
 
     @BeforeClass
     public static void setup() throws KernelException {
@@ -74,23 +76,15 @@ public class ShortestPathIntegrationTest {
                         "  (nC)-[:TYPE {cost:1.0}]->(nD),\n" +
                         "  (nD)-[:TYPE {cost:1.0}]->(nX)";
 
-
-        db = TestDatabaseCreator.createTestDatabase();
-        try (Transaction tx = db.beginTx()) {
-            db.execute(createGraph).close();
-            tx.success();
-        }
-
-        db.getDependencyResolver()
-                .resolveDependency(Procedures.class)
-                .registerProcedure(ShortestPathProc.class);
+        DB.execute(createGraph).close();
+        DB.resolveDependency(Procedures.class).registerProcedure(ShortestPathProc.class);
     }
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{"Heavy"},
-                new Object[]{"Light"},
+                new Object[]{"Huge"},
                 new Object[]{"Kernel"}
         );
     }
@@ -101,7 +95,7 @@ public class ShortestPathIntegrationTest {
     @Test
     public void testDijkstraStream() throws Exception {
         PathConsumer consumer = mock(PathConsumer.class);
-        db.execute(
+        DB.execute(
                 "MATCH (start:Node{type:'start'}), (end:Node{type:'end'}) " +
                         "CALL algo.shortestPath.stream(start, end, 'cost',{graph:'" + graphImpl + "'}) " +
                         "YIELD nodeId, cost RETURN nodeId, cost")
@@ -118,7 +112,7 @@ public class ShortestPathIntegrationTest {
 
     @Test
     public void testDijkstra() throws Exception {
-        db.execute(
+        DB.execute(
                 "MATCH (start:Node{type:'start'}), (end:Node{type:'end'}) " +
                         "CALL algo.shortestPath(start, end, 'cost',{graph:'" + graphImpl + "', write:true, writeProperty:'step'}) " +
                         "YIELD loadMillis, evalMillis, writeMillis, nodeCount, totalCost\n" +
@@ -134,9 +128,10 @@ public class ShortestPathIntegrationTest {
 
         final StepConsumer mock = mock(StepConsumer.class);
 
-        db.execute("MATCH (n) WHERE exists(n.step) RETURN id(n) as id, n.step as step")
+        DB.execute("MATCH (n) WHERE exists(n.step) RETURN id(n) as id, n.step as step")
                 .accept(row -> {
-                    mock.accept(row.getNumber("id").longValue(),
+                    mock.accept(
+                            row.getNumber("id").longValue(),
                             row.getNumber("step").intValue());
                     return true;
                 });
@@ -147,6 +142,68 @@ public class ShortestPathIntegrationTest {
         verify(mock, times(1)).accept(anyLong(), eq(1));
         verify(mock, times(1)).accept(anyLong(), eq(2));
         verify(mock, times(1)).accept(anyLong(), eq(3));
+    }
+
+    /** @see <a href="https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/599">Issue #599</a> */
+    @Test
+    public void test599() throws KernelException {
+        db_599.resolveDependency(Procedures.class).registerProcedure(ShortestPathProc.class);
+        final String create = "CREATE\n" +
+                "    (v1:Node {VID: 1})\n" +
+                "  , (v2:Node {VID: 2})\n" +
+                "  , (v3:Node {VID: 3})\n" +
+                "  , (v4:Node {VID: 4})\n" +
+                "  , (v5:Node {VID: 5})\n" +
+                "  , (v6:Node {VID: 6})\n" +
+                "  , (v7:Node {VID: 7})\n" +
+                "  ,(v1)-[:EDGE {WEIGHT: 0.5}]->(v2)\n" +
+                "  ,(v1)-[:EDGE {WEIGHT: 5.0}]->(v3)\n" +
+                "  ,(v2)-[:EDGE {WEIGHT: 0.5}]->(v5)\n" +
+                "  ,(v3)-[:EDGE {WEIGHT: 2.0}]->(v4)\n" +
+                "  ,(v5)-[:EDGE {WEIGHT: 0.5}]->(v6)\n" +
+                "  ,(v6)-[:EDGE {WEIGHT: 0.5}]->(v3)\n" +
+                "  ,(v6)-[:EDGE {WEIGHT: 23.0}]->(v7)\n" +
+                "  ,(v1)-[:EDGE {WEIGHT: 5.0}]->(v4)\n" +
+                "";
+        db_599.execute(create);
+
+        final String totalCostCommand = "" +
+                "MATCH (startNode {VID: 1}), (endNode {VID: 4})\n" +
+                "CALL algo.shortestPath(startNode, endNode, 'WEIGHT', {direction: 'OUTGOING'})\n" +
+                "YIELD nodeCount, totalCost, loadMillis, evalMillis, writeMillis\n" +
+                "RETURN totalCost\n";
+
+        double totalCost = db_599
+                .execute(totalCostCommand)
+                .<Double>columnAs("totalCost")
+                .stream()
+                .findFirst()
+                .orElse(Double.NaN);
+
+        assertEquals(4.0, totalCost, 1e-4);
+
+        final String pathCommand = "" +
+                "MATCH (startNode {VID: 1}), (endNode {VID: 4})\n" +
+                "CALL algo.shortestPath.stream(startNode, endNode, 'WEIGHT', {direction: 'OUTGOING'})\n" +
+                "YIELD nodeId, cost\n" +
+                "MATCH (n1) WHERE id(n1) = nodeId\n" +
+                "RETURN n1.VID as id, cost as weight\n";
+
+        List<Matcher<Number>> expectedList = Arrays.asList(
+                is(1L), is(0.0),
+                is(2L), is(0.5),
+                is(5L), is(1.0),
+                is(6L), is(1.5),
+                is(3L), is(2.0),
+                is(4L), is(4.0));
+        Iterator<Matcher<Number>> expected = expectedList.iterator();
+
+        final Result pathResult = db_599.execute(pathCommand);
+        pathResult.forEachRemaining(res -> {
+            assertThat((Number) res.get("id"), expected.next());
+            assertThat((Number) res.get("weight"), expected.next());
+        });
+        pathResult.close();
     }
 
     private interface PathConsumer {

--- a/tests/src/test/java/org/neo4j/graphalgo/core/utils/queue/IntMinPriorityQueueTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/utils/queue/IntMinPriorityQueueTest.java
@@ -37,14 +37,14 @@ import static org.junit.Assert.assertTrue;
 public final class IntMinPriorityQueueTest extends RandomizedTest {
 
     @Test
-    public void testIsEmpty() throws Exception {
+    public void testIsEmpty() {
         final int capacity = RandomizedTest.between(10, 20);
         final IntPriorityQueue queue = IntPriorityQueue.min(capacity);
         assertEquals(queue.size(), 0);
     }
 
     @Test
-    public void testClear() throws Exception {
+    public void testClear() {
         final int maxSize = RandomizedTest.between(3, 10);
         final IntPriorityQueue queue = IntPriorityQueue.min(maxSize);
         final int iterations = RandomizedTest.between(3, maxSize);
@@ -57,7 +57,7 @@ public final class IntMinPriorityQueueTest extends RandomizedTest {
     }
 
     @Test
-    public void testGrowing() throws Exception {
+    public void testGrowing() {
         final int maxSize = RandomizedTest.between(10, 20);
         final IntPriorityQueue queue = IntPriorityQueue.min(1);
         for (int i = 0; i < maxSize; i++) {
@@ -67,7 +67,7 @@ public final class IntMinPriorityQueueTest extends RandomizedTest {
     }
 
     @Test
-    public void testAdd() throws Exception {
+    public void testAdd() {
         final int iterations = RandomizedTest.between(5, 50);
         final IntPriorityQueue queue = IntPriorityQueue.min();
         int min = -1;
@@ -78,12 +78,13 @@ public final class IntMinPriorityQueueTest extends RandomizedTest {
                 minWeight = weight;
                 min = i;
             }
-            assertEquals(queue.add(i, weight), min);
+            queue.add(i, weight);
+            assertEquals(queue.top(), min);
         }
     }
 
     @Test
-    public void testAddAndPop() throws Exception {
+    public void testAddAndPop() {
         final IntPriorityQueue queue = IntPriorityQueue.min();
         final List<Pair<Integer, Double>> elements = new ArrayList<>();
 
@@ -96,7 +97,8 @@ public final class IntMinPriorityQueueTest extends RandomizedTest {
                 minWeight = weight;
                 min = i;
             }
-            assertEquals(queue.add(i, weight), min);
+            queue.add(i, weight);
+            assertEquals(queue.top(), min);
             elements.add(Pair.of(i, weight));
         }
 
@@ -123,6 +125,70 @@ public final class IntMinPriorityQueueTest extends RandomizedTest {
         }
 
         assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void testUpdateDecreasing() {
+        final IntPriorityQueue queue = IntPriorityQueue.min();
+
+        final int iterations = RandomizedTest.between(5, 50);
+        double minWeight = Double.POSITIVE_INFINITY;
+        for (int i = 1; i <= iterations; i++) {
+            final double weight = exclusiveDouble(50d, 100d);
+            if (weight < minWeight) {
+                minWeight = weight;
+            }
+            queue.add(i, weight);
+        }
+
+        for (int i = iterations; i >= 1; i--) {
+            minWeight = Math.nextDown(minWeight);
+            queue.addCost(i, minWeight);
+            queue.update(i);
+            assertEquals(i, queue.top());
+        }
+    }
+
+    @Test
+    public void testUpdateIncreasing() {
+        final IntPriorityQueue queue = IntPriorityQueue.min();
+        final int iterations = RandomizedTest.between(5, 50);
+        for (int i = 1; i <= iterations; i++) {
+            queue.add(i, exclusiveDouble(50d, 100d));
+        }
+
+        final int top = queue.top();
+        for (int i = iterations + 1; i < iterations + 10; i++) {
+            queue.addCost(i, 1d);
+            queue.update(i);
+            assertEquals(top, queue.top());
+        }
+    }
+
+    @Test
+    public void testUpdateNotExisting() {
+        final IntPriorityQueue queue = IntPriorityQueue.min();
+
+        final int iterations = RandomizedTest.between(5, 50);
+        double maxWeight = Double.NEGATIVE_INFINITY;
+        for (int i = 1; i <= iterations; i++) {
+            final double weight = exclusiveDouble(50d, 100d);
+            if (weight > maxWeight) {
+                maxWeight = weight;
+            }
+            queue.add(i, weight);
+        }
+
+        int top = queue.top();
+        for (int i = iterations; i >= 1; i--) {
+            if (i == top) {
+                continue;
+            }
+            maxWeight = Math.nextUp(maxWeight);
+            queue.addCost(i, maxWeight);
+            queue.update(i);
+            assertEquals(top, queue.top());
+        }
     }
 
     private double exclusiveDouble(

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/ShortestPathDijkstraTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/ShortestPathDijkstraTest.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import java.util.Arrays;
@@ -91,6 +90,24 @@ public final class ShortestPathDijkstraTest {
             "  (n5)-[:TYPE2 {cost:10}]->(n7),\n" +
             "  (n6)-[:TYPE2 {cost:1}]->(n7)\n";
 
+    private static final String DB_CYPHER_599 = "" +
+            "CREATE (n1:Label599 {id:\"1\"})\n" +
+            "CREATE (n2:Label599 {id:\"2\"})\n" +
+            "CREATE (n3:Label599 {id:\"3\"})\n" +
+            "CREATE (n4:Label599 {id:\"4\"})\n" +
+            "CREATE (n5:Label599 {id:\"5\"})\n" +
+            "CREATE (n6:Label599 {id:\"6\"})\n" +
+            "CREATE (n7:Label599 {id:\"7\"})\n" +
+            "CREATE\n" +
+            "  (n1)-[:TYPE599 {cost:0.5}]->(n2),\n" +
+            "  (n1)-[:TYPE599 {cost:5.0}]->(n3),\n" +
+            "  (n2)-[:TYPE599 {cost:0.5}]->(n5),\n" +
+            "  (n3)-[:TYPE599 {cost:2.0}]->(n4),\n" +
+            "  (n5)-[:TYPE599 {cost:0.5}]->(n6),\n" +
+            "  (n6)-[:TYPE599 {cost:0.5}]->(n3),\n" +
+            "  (n6)-[:TYPE599 {cost:23.0}]->(n7),\n" +
+            "  (n1)-[:TYPE599 {cost:5.0}]->(n4)";
+
     @Parameterized.Parameters(name = "{1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
@@ -104,9 +121,10 @@ public final class ShortestPathDijkstraTest {
     public static final ImpermanentDatabaseRule DB = new ImpermanentDatabaseRule();
 
     @BeforeClass
-    public static void setupGraph() throws KernelException {
+    public static void setupGraph() {
         DB.execute(DB_CYPHER).close();
         DB.execute(DB_CYPHER2).close();
+        DB.execute(DB_CYPHER_599).close();
     }
 
     private Class<? extends GraphFactory> graphImpl;
@@ -120,7 +138,7 @@ public final class ShortestPathDijkstraTest {
     }
 
     @Test
-    public void test1() throws Exception {
+    public void test1() {
         final Label label = Label.label("Label1");
         RelationshipType type = RelationshipType.withName("TYPE1");
 
@@ -134,7 +152,7 @@ public final class ShortestPathDijkstraTest {
 
         final Graph graph = new GraphLoader(DB)
                 .withLabel(label)
-                .withRelationshipType("TYPE1")
+                .withRelationshipType(type)
                 .withRelationshipWeightsFromProperty("cost", Double.MAX_VALUE)
                 .withDirection(Direction.OUTGOING)
                 .load(graphImpl);
@@ -148,7 +166,7 @@ public final class ShortestPathDijkstraTest {
     }
 
     @Test
-    public void test2() throws Exception {
+    public void test2() {
         final Label label = Label.label("Label2");
         RelationshipType type = RelationshipType.withName("TYPE2");
         ShortestPath expected = expected(label, type,
@@ -160,7 +178,7 @@ public final class ShortestPathDijkstraTest {
 
         final Graph graph = new GraphLoader(DB)
                 .withLabel(label)
-                .withRelationshipType("TYPE2")
+                .withRelationshipType(type)
                 .withRelationshipWeightsFromProperty("cost", Double.MAX_VALUE)
                 .withDirection(Direction.OUTGOING)
                 .load(graphImpl);
@@ -173,8 +191,40 @@ public final class ShortestPathDijkstraTest {
         assertArrayEquals(nodeIds, path);
     }
 
+    /** @see <a href="https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/599">Issue #599</a> */
     @Test
-    public void testResultStream() throws Exception {
+    public void test599() {
+        Label label = Label.label("Label599");
+        RelationshipType type = RelationshipType.withName("TYPE599");
+        ShortestPath expected = expected(
+                label, type,
+                "id", "1", "id", "2", "id", "5",
+                "id", "6", "id", "3", "id", "4");
+
+        Graph graph = new GraphLoader(DB)
+                .withLabel(label)
+                .withRelationshipType(type)
+                .withRelationshipWeightsFromProperty("cost", Double.MAX_VALUE)
+                .withDirection(Direction.OUTGOING)
+                .load(graphImpl);
+
+        ShortestPathDijkstra shortestPathDijkstra = new ShortestPathDijkstra(graph);
+        shortestPathDijkstra.compute(
+                expected.nodeIds[0],
+                expected.nodeIds[expected.nodeIds.length - 1],
+                Direction.OUTGOING
+        );
+        long[] path = Arrays
+                .stream(shortestPathDijkstra.getFinalPath().toArray())
+                .mapToLong(graph::toOriginalNodeId)
+                .toArray();
+
+        assertArrayEquals(expected.nodeIds, path);
+        assertEquals(expected.weight, shortestPathDijkstra.getTotalCost(), 0.1);
+    }
+
+    @Test
+    public void testResultStream() {
         final Label label = Label.label("Label1");
         RelationshipType type = RelationshipType.withName("TYPE1");
         ShortestPath expected = expected(label, type,


### PR DESCRIPTION
Reported and based on the examples in #599, also fixes #599.

The basic issue is that the priority queue doesn't support duplicate values, but we might enqueue a node multiple times with different weights, coming from different paths.
The PQ is an array based heap and new nodes are enqueued by adding them to the end and then bubbling them up to their correct place.

First, we discover the target node (3) with a weight of 5 – it is places in the heap.
Then we discover the node (2) with a weight of 5. It's placed at the end of heap and doesn't bubble up, since its weight is not less than that of the previous node.
Then we discover a new path to (2) with a weight of 2. (2) is now placed at the end of the heap again and should bubble up, but the first check happens against the previously inserted node 2, for which the cost has changed as well.
Instead of moving in front of the node (3), the new (2) stays at the end (besides being twice in the queue) and the heap invariant is broken, as the smalled node is no longer at the front.
On the next queue.pop, we get (3) instead of (2) and think that we are finished with the path finding.
If we had discovered (2) first and (3) later, it would have worked by accident; the order of relationship traversal during the import matters here, as it defines whether we check (2) or (3) first.

To fix this, I added an update method to the PQ, which searches for an element in the queue and moves it to its proper place.
If we change the current cost leading up to a node, that we update the queue instead of adding the node again.

I also patched up A* and ShortesPath_s_, as well as AllShortesPaths, although that one would have eventually found all shortest paths, even if the queue was in a broken and suboptimal state during the algo run.
I've also thrown in a fix for the bitset, so that it doesn't copy its buffer on every put.
