### PR TITLE
Standardize header format in the docs (on consistent headers)

### DIFF
--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -15,7 +15,7 @@ In this scenario the algorithm will return `Infinity` value as a result between 
 
 Plain cypher does not support filtering `Infinity` values, so `algo.isFinite` function was added to help filter `Infinity` values from results.
 
-== When to use it / use-cases
+== Use-cases - when to use the All Pairs Shortest Path algorithm
 
 // tag::use-case[]
 
@@ -90,7 +90,7 @@ include::scripts/single-shortest-path.cypher[tag=all-pairs-bidirected-graph]
 ----
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 

--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -35,7 +35,7 @@ There are more details about this approach in https://cs.uwaterloo.ca/research/t
 // end::constraint[]
 
 
-== Algorithm explanation on simple sample graph
+== All Pairs Shortest Path algorithm sample
 
 image::sssp.png[]
 

--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -6,7 +6,7 @@ This algorithm has optimisations that make it quicker than calling the SSSP algo
 
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 Some pairs of nodes might not be reachable between each other, so no shortest path exist between these pairs of nodes.

--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -28,7 +28,7 @@ There are more details about this approach in https://cs.uwaterloo.ca/research/t
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the All Pairs Shortest Path algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -118,7 +118,7 @@ ifdef::implementation[]
 * [2] https://cs.uwaterloo.ca/research/tr/2011/CS-2011-21.pdf[REWIRE: An optimization-based framework for unstructured data center network design^] - Andrew R. Curtis, Tommy Carpenter, Mustafa Elsheikh, Alejandro López-Ortiz, S. Keshav
 // end::references[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -28,7 +28,7 @@ In our implementation geospatial distance is used as heurestic.
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the A* algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -141,7 +141,7 @@ We support the following versions of the shortest path algorithms:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -20,7 +20,7 @@ In our implementation geospatial distance is used as heurestic.
 
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the A* algorithm
 
 // tag::use-case[]
 
@@ -56,7 +56,7 @@ include::scripts/astar.cypher[tag=stream-sample-graph]
 | King's Cross St. Pancras | 0
 | Euston | 2
 | Camden Town | 5
-| Kentish Town | 7 
+| Kentish Town | 7
 |===
 // end::stream-sample-graph-result[]
 
@@ -65,7 +65,7 @@ include::scripts/astar.cypher[tag=stream-sample-graph]
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.shortestPath.astar.stream((startNode:Node, endNode:Node, weightProperty:String, propertyKeyLat:String, 
+CALL algo.shortestPath.astar.stream((startNode:Node, endNode:Node, weightProperty:String, propertyKeyLat:String,
 propertyKeyLon:String, {nodeQuery:'labelName', relationshipQuery:'relationshipName', direction:'BOTH', defaultValue:1.0})
 YIELD nodeId, cost - yields a stream of {nodeId, cost} from start to end (inclusive)
 ----
@@ -90,7 +90,7 @@ YIELD nodeId, cost - yields a stream of {nodeId, cost} from start to end (inclus
 |===
 | name | type | description
 | nodeId | int | node id
-| cost | int | cost it takes to get from start node to specific node 
+| cost | int | cost it takes to get from start node to specific node
 |===
 
 == Cypher projection
@@ -104,15 +104,15 @@ Set `graph:'cypher'` in the config.
 include::scripts/astar.cypher[tag=cypher-loading]
 ----
 
-== Versions 
+== Versions
 
 We support the following versions of the shortest path algorithms:
 
-* [x] directed, unweighted:  
+* [x] directed, unweighted:
 
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null
 
-* [x] directed, weighted 
+* [x] directed, weighted
 
 ** direction: 'OUTGOING' or INCOMING, weightProperty: 'cost'
 
@@ -120,7 +120,7 @@ We support the following versions of the shortest path algorithms:
 
 ** direction: 'BOTH', weightProperty: null
 
-* [x] undirected, weighted 
+* [x] undirected, weighted
 
 ** direction: 'BOTH', weightProperty: 'cost'
 
@@ -151,7 +151,7 @@ ifdef::implementation[]
 - [x] implement procedure
 - [x] tests
 - [x] relationship case tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [] benchmark on bigger graphs
 - [] parallelization
 - [] evaluation

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -34,7 +34,7 @@ In our implementation geospatial distance is used as heurestic.
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== A* algorithm sample
 
 .Create sample graph
 [source,cypher]

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -7,7 +7,7 @@ It  is  based  on  the  observation  that  some  searches  are informed, and  th
 
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 

--- a/doc/asciidoc/betweenness-centrality-ra-brandes.adoc
+++ b/doc/asciidoc/betweenness-centrality-ra-brandes.adoc
@@ -32,7 +32,7 @@ include::scripts/betweenness-centrality.cypher[tag=stream-rabrandes-graph]
 include::scripts/betweenness-centrality.cypher[tag=write-rabrandes-graph]
 ----
 
-= Example Usage
+= Example usage
 
 = Syntax
 

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -42,7 +42,7 @@ Impact of a Focal User]
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Betweenness Centrality algorithm
 
 // tag::constraint[]
 Betweeness centrality makes the assumption that all communication between nodes happens along the shortest path and with the same frequency, which isn't the case in real life.

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -183,7 +183,7 @@ We support the following versions of the betweenness centrality algorithm:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/98

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -11,7 +11,7 @@ If Alice is removed all connections in the graph would be cut off.
 This makes Alice "important" because she ensures that no nodes are isolated.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 The betweenness centrality algorithm calculates the shortest (weighted) path between every pair of nodes in a connected graph using the breadth-first search algorithm.

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -22,7 +22,7 @@ The algorithm was given its first formal definition by Linton Freeman in his 197
 It was considered to be one of the "three distinct intuitive conceptions of centrality".
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Betweenness Centrality algorithm
 
 // tag::use-case[]
 
@@ -37,7 +37,7 @@ More detail can be found in http://archives.cerium.ca/IMG/pdf/Morselli_and_Roy_2
 
 * Betweenness centrality can be used to help micro bloggers spread their reach on Twitter network with a recommendation engine that targets influencers they should interact with in future.
 This approach is described in ftp://ftp.umiacs.umd.edu/incoming/louiqa/PUB2012/RecMB.pdf[Making Recommendations in a Microblog to Improve the
-Impact of a Focal User] 
+Impact of a Focal User]
 
 
 // end::use-case[]
@@ -80,13 +80,13 @@ include::scripts/betweenness-centrality.cypher[tag=write-sample-graph]
 .Results
 [opts="header",cols="1,1"]
 |===
-| name | centrality weight 
+| name | centrality weight
 | Alice | 4
 | Charles | 2
 | Bridget | 0
 | Michael | 0
 | Doug | 0
-| Mark | 0 
+| Mark | 0
 |===
 // end::stream-sample-graph-result[]
 
@@ -108,7 +108,7 @@ Set `graph:'cypher'` in the config.
 include::scripts/betweenness-centrality.cypher[tag=cypher-loading]
 ----
 
-== Versions 
+== Versions
 
 We support the following versions of the betweenness centrality algorithm:
 
@@ -123,7 +123,7 @@ We support the following versions of the betweenness centrality algorithm:
 
 ** direction:'both' or '<>'
 
-* [ ] undirected, weighted 
+* [ ] undirected, weighted
 
 == Implementations
 
@@ -139,7 +139,7 @@ We support the following versions of the betweenness centrality algorithm:
 - brandes-like algorithm which uses successor sets instead of predecessor sets
 - The algorithm is based on Brandes definition but with some changes
  regarding the dependency-accumulation step.
-- Does not support undirected graph 
+- Does not support undirected graph
 
 `algo.betweenness.sampled()`
 
@@ -147,7 +147,7 @@ We support the following versions of the betweenness centrality algorithm:
 
 - random selection(default): strategy:'random': (takes optional argument probability:double(0-1) or log10(N) / e^2 as default)
 - degree based randomization: strategy:'degree': (makes dense nodes more likely)
-- optional Arguments: maxDepth:int 
+- optional Arguments: maxDepth:int
 
 
 == References
@@ -196,7 +196,7 @@ In graph theory, betweenness centrality is a measure of centrality in a graph ba
 - [x] implement procedure
 - [x] tests
 - [x] relationship case tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] benchmark on bigger graphs
 - [x] parallelization
 - [x] evaluation
@@ -226,7 +226,7 @@ In graph theory, betweenness centrality is a measure of centrality in a graph ba
 
 - random selection(default): strategy:'random': (takes optional argument probability:double(0-1) or log10(N) / e^2 as default)
 - degree based randomization: strategy:'degree': (makes dense nodes more likely)
-- optional Arguments: maxDepth:int 
+- optional Arguments: maxDepth:int
 
 
 // end::implementation[]

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -53,7 +53,7 @@ The fastest known algorithm for exactly computing betweenness of all the nodes r
 Instead we can use an approximation algorithm that works with a subset of nodes.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Betweenness Centrality algorithm sample
 
 People with high betweenness tend to be the innovators and brokers in social networks.
 They combine different perspectives, transfer ideas between groups, and get power from their ability to make introductions and pull strings.

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -46,7 +46,7 @@ This process is described by Florian Boudin in https://www.aclweb.org/anthology/
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Closeness Centrality algorithm
 
 // tag::constraint[]
 Academically closeness centrality works best on connected graphs.

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -56,7 +56,7 @@ This means that we'll end up with an infinite closeness centrality score when we
 In practice, a variation on the original formula is used so that we don't run into these issues.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Closeness Centrality algorithm sample
 
 image::closeness_centrality.png[]
 

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -242,7 +242,7 @@ We support the following versions of the closeness centrality algorithm:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/99

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -124,7 +124,7 @@ k/S| 0.4  0.57  0.67  0.57   0.4     // normalized closeness centrality
 
 
 
-== Example Usage
+== Example usage
 
 == Syntax
 

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -30,7 +30,7 @@ The formula for *normalized closeness centrality* is as follows:
 `normalized closeness centrality(node) = (number of nodes - 1) / sum(distance from node to all other nodes)`
 // end::formula[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Closeness Centrality algorithm
 
 // tag::use-case[]
 
@@ -188,7 +188,7 @@ YIELD nodeId, centrality - yields centrality for each node
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -7,7 +7,7 @@ The _Closeness Centrality_ of a node measures its average distance to all other 
 Nodes with a high closeness score have the shortest distances to all other nodes.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 For each node the algorithm calculates the sum of its distances to all other nodes based on calculating shortest paths between all pairs of nodes.

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -31,7 +31,7 @@ Read more in https://pdfs.semanticscholar.org/a8e0/5f803312032569688005acadaa4d4
 // end::use-case[]
 
 
-== Constraints / when not to use it
+== Constraints - when not to use the Connected Components algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -124,7 +124,7 @@ include::scripts/connected-components.cypher[tag=weighted-write-sample-graph]
 In this case we can see that because the weight of the relationship betwen Bridget and Alice is only 0.5, the relationship is ignored by the algorithm and Bridget ends up in her own component.
 // end::weighted-stream-sample-graph-explanation[]
 
-== Example Usage
+== Example usage
 
 As said Connected Components are an essential step in preprocessing your data.
 One reason is that most centralities suffer from disconnected components or you just want to find disconnected groups of nodes.

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -13,12 +13,12 @@ The algorithm was first described by Bernard A. Galler and Michael J. Fischer in
 The components in a graph are computed using either the breadth-first search or depth-first search algorithms.
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Connected Components algorithm
 
 // tag::use-case[]
 
 * Testing whether a graph is connected is an essential pre-processing step for every graph algorithm.
-Such tests can be performed so quickly and easily that you should always verify that your input graph is connected, even when you know it has to be. 
+Such tests can be performed so quickly and easily that you should always verify that your input graph is connected, even when you know it has to be.
 Subtle, difficult-to-detect bugs often result when your algorithm is run only on one component of a disconnected graph.
 
 * Union Find can be used to keep track of clusters of database records as part of the de-duplication process - an important task in master data management applications.
@@ -39,8 +39,8 @@ Read more in https://pdfs.semanticscholar.org/a8e0/5f803312032569688005acadaa4d4
 
 == Algorithm explanation on simple sample graph
 
-Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph between those vertices. 
-A connected component of an undirected graph is a maximal connected subgraph of the graph. 
+Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph between those vertices.
+A connected component of an undirected graph is a maximal connected subgraph of the graph.
 That means that the direction of the relationships in our graph have are ignored - we treat the graph as undirected.
 
 We have two implementations of connected components algorithm.
@@ -77,7 +77,7 @@ include::scripts/connected-components.cypher[tag=unweighted-write-sample-graph]
 | Bridget | 0
 | Michael | 4
 | Doug | 4
-| Mark | 4 
+| Mark | 4
 |===
 // end::unweighted-stream-sample-graph-result[]
 
@@ -116,7 +116,7 @@ include::scripts/connected-components.cypher[tag=weighted-write-sample-graph]
 | Bridget | 1
 | Michael | 4
 | Doug | 4
-| Mark | 4 
+| Mark | 4
 |===
 // end::weighted-stream-sample-graph-result[]
 
@@ -126,8 +126,8 @@ In this case we can see that because the weight of the relationship betwen Bridg
 
 == Example Usage
 
-As said Connected Components are an essential step in preprocessing your data. 
-One reason is that most centralities suffer from disconnected components or you just want to find disconnected groups of nodes. 
+As said Connected Components are an essential step in preprocessing your data.
+One reason is that most centralities suffer from disconnected components or you just want to find disconnected groups of nodes.
 Yelp's social network will be used to demonstrate how to proceed when dealing with real world data.
 A typical social network consist of one big component and a number of small disconnected components.
 
@@ -137,7 +137,7 @@ A typical social network consist of one big component and a number of small disc
 include::scripts/connected-components.cypher[tag=count-component-yelp]
 ----
 
-We get back count of disconnected components being 18512 if we do not count users without friends. 
+We get back count of disconnected components being 18512 if we do not count users without friends.
 Let's now check the size of top 20 components to get a better picture
 
 .Get the size of top 20 components
@@ -158,9 +158,9 @@ We just simply write back the results to the node, and use centralities with cyp
 [source,cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy',concurrency:4}) 
+defaultValue:1.0, write: true, partitionProperty:'partition',weightProperty:'weight',graph:'heavy',concurrency:4})
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
-- finds connected partitions and potentially writes back to the node as a property partition. 
+- finds connected partitions and potentially writes back to the node as a property partition.
 
 ----
 
@@ -194,7 +194,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0, concurrency:4}) 
+CALL algo.unionFind.stream(label:String, relationship:String, {weightProperty:'weight', threshold:0.42, defaultValue:1.0, concurrency:4})
 YIELD nodeId, setId - yields a setId to each node id
 ----
 
@@ -220,7 +220,7 @@ YIELD nodeId, setId - yields a setId to each node id
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 
@@ -293,7 +293,7 @@ _Connected Components_ or _UnionFind_ basically finds sets of connected nodes wh
 
 - [x] single threaded implementation
 - [x] tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] implement procedure
 - [x] benchmark on bigger graphs
 - [x] parallelization
@@ -311,7 +311,7 @@ We use a disjoint-set-structure which is based on a parent-array-tree. The DSS c
 
 ### benchmark
 
-Implement benchmark on big graph & 
+Implement benchmark on big graph &
 
 - stream nodeId-setId pairs
 - calculate setSize-setCount

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -37,7 +37,7 @@ Read more in https://pdfs.semanticscholar.org/a8e0/5f803312032569688005acadaa4d4
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Connected Components algorithm sample
 
 Recall that an undirected graph is connected if for every pair of vertices, there is a path in the graph between those vertices.
 A connected component of an undirected graph is a maximal connected subgraph of the graph.

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -282,7 +282,7 @@ the calculation of the DSS is done by the ExecutorService.
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/79

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -6,7 +6,7 @@ It differs from the SCC algorithm because it only needs a path to exist between 
 As with SCC, UnionFind is often used early in an analysis to understand a graph's structure.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 The algorithm was first described by Bernard A. Galler and Michael J. Fischer in 1964.

--- a/doc/asciidoc/degree-centrality.adoc
+++ b/doc/asciidoc/degree-centrality.adoc
@@ -16,7 +16,7 @@ While the algorithm can be used to find the popularity of individual nodes, it i
 // end::explanation[]
 
 
-== When to use it / use-cases
+== Use-cases - when to use the Degree Centrality algorithm
 
 
 // tag::use-case[]

--- a/doc/asciidoc/degree-centrality.adoc
+++ b/doc/asciidoc/degree-centrality.adoc
@@ -30,7 +30,7 @@ Read more in https://link.springer.com/chapter/10.1007/978-3-319-23461-8_11[Two 
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Degree Centrality algorithm
 
 
 // tag::constraint[]

--- a/doc/asciidoc/degree-centrality.adoc
+++ b/doc/asciidoc/degree-centrality.adoc
@@ -38,7 +38,7 @@ Read more in https://link.springer.com/chapter/10.1007/978-3-319-23461-8_11[Two 
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Degree Centrality algorithm sample
 
 .Create sample graph
 [source,cypher]

--- a/doc/asciidoc/degree-centrality.adoc
+++ b/doc/asciidoc/degree-centrality.adoc
@@ -7,7 +7,7 @@ It measures the number of incoming and outgoing relationships from a node.
 The algorithm can help us find popular nodes in a graph.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 Degree Centrality was proposed by Linton C. Freeman in his 1979 paper http://leonidzhukov.net/hse/2014/socialnetworks/papers/freeman79-centrality.pdf[Centrality in Social Networks Conceptual Clarification^].

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -5,7 +5,7 @@ Harmonic centrality (also known as 'valued centrality') is a variant of closenes
 As with many of the centrality algorithms, it originates from the field of social network analysis.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 Harmonic centrality was proposed by Marchiori and Latora [1] while trying to come up with a sensible notion of "average shortest path".

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -95,7 +95,7 @@ of each cell and multiply by 1/(n-1)
 
 
 
-== Example Usage
+== Example usage
 
 == Syntax
 

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -36,7 +36,7 @@ For example, we might use it if we're trying to identify where in the city to pl
 If we're trying to spread a message on social media we could use the algorithm to find the key influencers that can help us achieve our goal.
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Harmonic Centrality algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -42,7 +42,7 @@ If we're trying to spread a message on social media we could use the algorithm t
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Harmonic Centrality algorithm sample
 
 // image::harmonic_centrality.png[]
 

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -204,7 +204,7 @@ We support the following versions of the harmonic centrality algorithm:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 ...
 

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -27,7 +27,7 @@ As with closeness centrality we can also calculate a *normalized harmonic centra
 In this formula ∞ values are handled cleanly.
 // end::formula[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Harmonic Centrality algorithm
 
 // tag::use-case[]
 Harmonic centrality was proposed as an alternative to closeness centrality, and therefore has similar use cases.
@@ -158,7 +158,7 @@ YIELD nodeId, centrality - yields centrality for each node
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -41,7 +41,7 @@ Nodes that have the same label at convergence are said to belong to the same com
 * Label propagation has been used to infer features of utterances in a dialogue for a machine learning model to track user intention with the help of Wikidata knowledge graph of concepts and their relations. Get more details in https://www.uni-ulm.de/fileadmin/website_uni_ulm/iui.iwsds2017/papers/IWSDS2017_paper_12.pdf[Feature Inference Based on Label Propagation on Wikidata Graph for DST]
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Label Propagation algorithm
 
 // tag::constraint[]
 In contrast with other algorithms label propagation can result in different community structures when run multiple times on the same graph.

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -230,7 +230,7 @@ We support the following versions of the label propagation algorithms:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/95

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -31,7 +31,7 @@ At the end of the propagation only a few labels will remain - most will have dis
 Nodes that have the same label at convergence are said to belong to the same community.
 // end::formula[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Label Propagation algorithm
 
 
 // tag::use-case[]
@@ -156,7 +156,7 @@ partitionProperty - simple label propagation kernel
 [source,cypher]
 ----
 CALL algo.labelPropagation.stream(label:String, relationship:String, {iterations:1,
-weightProperty:'weight', partitionProperty:'partition', concurrency:4, direction:'OUTGOING'}) 
+weightProperty:'weight', partitionProperty:'partition', concurrency:4, direction:'OUTGOING'})
 YIELD nodeId, label
 ----
 
@@ -235,7 +235,7 @@ ifdef::implementation[]
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/95
 
-_Label Propagation_ is a graph partitioning algorithm already implemented in current apoc-procedures. 
+_Label Propagation_ is a graph partitioning algorithm already implemented in current apoc-procedures.
 
 ## Progress
 
@@ -244,7 +244,7 @@ _Label Propagation_ is a graph partitioning algorithm already implemented in cur
 - [x] tests
 - [ ] edge case tests
 - [x] implement procedure
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] benchmark on bigger graphs
 - [x] parallelization
 - [x] evaluation

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -108,7 +108,7 @@ Using this preliminary set of labels (identifiers) it then sequentially updates 
 include::scripts/label-propagation.cypher[tag=write-existing-label-sample-graph]
 ----
 
-== Example Usage
+== Example usage
 
 == Syntax
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -49,7 +49,7 @@ The range of solutions can be narrowed if some nodes are given preliminary label
 Unlabelled nodes will be more likely to adapt the preliminary labels.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Label Propagation algorithm sample
 
 image::label_propagation.png[]
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -8,7 +8,7 @@ One interesting feature of LPA is that we can give nodes preliminary labels to n
 This means that it can be used as semi-supervised way of finding communities where we hand-pick some initial communities.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 LPA is a relatively new algorithm and was only proposed by https://arxiv.org/pdf/0709.2938.pdf[Raghavan et al.^] in 2007.

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -9,7 +9,7 @@ The _Louvain_ algorithm is one of the fastest modularity based algorithms and wo
 It also reveals a hierarchy of communities at different scales, which can be useful for understanding the global functioning of a network.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 The https://arxiv.org/pdf/0803.0476.pdf[Louvain algorithm^] was proposed in 2008 by authors from the University of Louvain.

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -243,7 +243,7 @@ ifdef::implementation[]
 // tag::implementation[]
 
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/96

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -60,7 +60,7 @@ Study mentioned is https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2784301/[Hierarc
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Louvain algorithm
 
 // tag::constraint[]
 Although the _Louvain_ Method, and modularity optimization algorithms more generally, have found wide application across many domains, some problems with these algorithms have been identified.

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -121,7 +121,7 @@ Mark, Doug, and Charles are all friends with each other, as are Bridget, Alice, 
 Charles is the only one who has friends in both communities but he has more in community 4 so he fits better in that one.
 // end::stream-sample-graph-explanation[]
 
-== Example Usage
+== Example usage
 
 
 

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -27,7 +27,7 @@ The algorithm is initialized with each node in its own community.
 
 In the first stage we iterate through each of the nodes in the network.
 We take each node, remove it from its current community and replace it in the community of ones of its neighbors.
-We compute the modularity change for each of the node's neighbors. 
+We compute the modularity change for each of the node's neighbors.
 If none of these modularity changes are positive, the node stays in its current community.
 If some of the modularity changes are positive, the node moves into the community where the modularity change is most positive.
 Ties are resolved arbitrarily.
@@ -37,7 +37,7 @@ The second stage in the Louvain Method uses the communities that were discovered
 In this network the newly discovered communities are the nodes.
 The relationship weight between the nodes representing two communities is the sum of the relationship weights between the lower-level nodes of each community.
 
-The rest of the Louvain Method consists of repeated application of stages 1 and 2. 
+The rest of the Louvain Method consists of repeated application of stages 1 and 2.
 By applying stage 1 (the community reassignment phase) to the coarse-grained graph, we find a second tier of communities of communities of nodes.
 Then, in the next application of stage 2, we define a new coarse-grained graph at this higher-level of the hierarchy.
 We keep going like this until an application of stage 1 yields no reassignments.
@@ -45,7 +45,7 @@ At that point repeated application of stages 1 and 2 will not yield any more mod
 // end::formula[]
 
 
-== When to use it / use-cases
+== Use-cases - when to use the Louvain algorithm
 
 // tag::use-case[]
 
@@ -65,7 +65,7 @@ Study mentioned is https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2784301/[Hierarc
 // tag::constraint[]
 Although the _Louvain_ Method, and modularity optimization algorithms more generally, have found wide application across many domains, some problems with these algorithms have been identified.
 
-The _resolution_ limit: 
+The _resolution_ limit:
 
 For larger networks the Louvain Method doesn't stop with the "intuitive" communities.
 Instead there's a second pass through the community modification and coarse-graining stages, in which several of the intuitive communities are merged together.
@@ -111,7 +111,7 @@ include::scripts/louvain.cypher[tag=write-sample-graph]
 | Michael | 5
 | Charles | 4
 | Doug | 4
-| Mark | 4 
+| Mark | 4
 |===
 // end::stream-sample-graph-result[]
 
@@ -193,7 +193,7 @@ YIELD nodeId, community - yields a community to each node id
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 
@@ -214,14 +214,14 @@ Set `graph:'cypher'` in the config.
 include::scripts/louvain.cypher[tag=cypher-loading]
 ----
 
-== Versions 
+== Versions
 
 * [x] undirected, unweighted
 
 ** weightProperty: null
 
 * [x] undirected, weighted
- 
+
 ** weightProperty : 'weight'
 
 == References
@@ -230,7 +230,7 @@ include::scripts/louvain.cypher[tag=cypher-loading]
 
 * [1] https://arxiv.org/pdf/0803.0476.pdf
 
-* [2] https://www.quora.com/Is-there-a-simple-explanation-of-the-Louvain-Method-of-community-detection 
+* [2] https://www.quora.com/Is-there-a-simple-explanation-of-the-Louvain-Method-of-community-detection
 
 * [3] https://arxiv.org/abs/0910.0165
 
@@ -248,13 +248,13 @@ ifdef::implementation[]
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/96
 
-_Louvain_ is an algorithm for detecting graph partitions in networks that relies upon a heuristic for maximizing the modularity. 
+_Louvain_ is an algorithm for detecting graph partitions in networks that relies upon a heuristic for maximizing the modularity.
 
 - [x] single threaded implementation
 - [x] tests
 - [ ] edge case tests
 - [x] implement procedure
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] benchmark on bigger graphs
 - [x] parallelization
 - [ ] evaluation

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -79,7 +79,7 @@ This can be a severe problem because, in the presence of a large number of high 
 https://arxiv.org/abs/0910.0165[Research] undertaken at Universite Catholique de Louvain showed that the different locally optimal community assignments can have quite different structural properties.[3]
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Louvain algorithm sample
 
 image::louvain.png[]
 

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -173,7 +173,7 @@ WHERE count = k
 RETURN n
 ----
 
-== Example Usage
+== Example usage
 
 == Syntax
 

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -6,7 +6,7 @@ _Prim's algorithm_ is one of the simplest and best-known minimum spanning tree a
 The K-Means variant of this algorithm can be used to detect clusters in the graph.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 The first known algorithm for finding a minimum spanning tree was developed by the Czech scientist Otakar Borůvka in 1926, while trying to find an efficient electricity network for Moravia.

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -39,7 +39,7 @@ Read more in the https://www.ncbi.nlm.nih.gov/pmc/articles/PMC516344/[Use of the
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Minimum Weight Spanning Tree algorithm
 
 // tag::constraint[]
 The MST algorithm only gives meaningful results when run on a graph where the relationships have different weights.

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -24,7 +24,7 @@ The algorithm operates as follows:
 * when there are no more nodes to add, the tree we have built is a minimum spanning tree.
 // end::formula[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Minimum Weight Spanning Tree algorithm
 
 // tag::use-case[]
 * Minimum spanning tree was applied to analyse airline and sea connections of Papua New Guinea and minimize the travel cost of exploring the country.
@@ -60,7 +60,7 @@ include::scripts/minimum-weight-spanning-tree.cypher[tag=create-sample-graph]
 
 Minimum weighted spanning tree visits all nodes that are in the same connected component as the starting node and returns a spanning tree of all nodes in the component where the total weight of the relationships is minimized.
 
-.Running minimum spanning tree algorithm and writing back results 
+.Running minimum spanning tree algorithm and writing back results
 [source,cypher]
 ----
 include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-minst-graph]
@@ -102,7 +102,7 @@ Nodes "F" and "G" aren't included because they're unreachable from "D".
 Maximum weighted tree spanning algorithm is similar to the minimum one, except that it returns a spanning tree of all nodes in the component where the total weight of the relationships is maximized.
 
 
-.Running maximum spanning tree algorithm and writing back results 
+.Running maximum spanning tree algorithm and writing back results
 [source,cypher]
 ----
 include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-maxst-graph]
@@ -114,14 +114,14 @@ image::maxst_result.png[]
 
 === k-Spanning tree
 
-Sometimes we want to limit the size of our spanning tree result as we are only interested in finding a smaller tree within our graph that does not span across all nodes. 
+Sometimes we want to limit the size of our spanning tree result as we are only interested in finding a smaller tree within our graph that does not span across all nodes.
 K-Spanning tree algorithm returns a tree with k nodes and k − 1 relationships.
 
 In our sample graph we have 5 nodes.
 When we ran MST above we got returned a 5-minimum spanning tree, that covered all five nodes.
 By setting the `k=3` we define that we want to get returned a 3-minimum spanning tree that covers 3 nodes and has 2 relationships.
 
-.Running k-minimum spanning tree algorithm and writing back results 
+.Running k-minimum spanning tree algorithm and writing back results
 [source,cypher]
 ----
 include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-kminst-graph]
@@ -131,17 +131,17 @@ include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-kminst-gra
 .Results
 [opts="header",cols="1,1"]
 |===
-| Place | partition 
+| Place | partition
 | A | 1
 | B | 1
 | C | 1
 | D | 3
-| E | 4 
+| E | 4
 |===
 
 Nodes A, B and C are the result 3-minimum spanning tree of our graph.
 
-.Running k-maximum spanning tree algorithm and writing back results 
+.Running k-maximum spanning tree algorithm and writing back results
 [source,cypher]
 ----
 include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-kmaxst-graph]
@@ -151,26 +151,26 @@ include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-kmaxst-gra
 .Results
 [opts="header",cols="1,1"]
 |===
-| Place | partition 
+| Place | partition
 | A | 0
 | B | 1
 | C | 3
 | D | 3
-| E | 3 
+| E | 3
 |===
 
 Nodes C, D and E are the result 3-maximum spanning tree of our graph.
 
 
-When we run this algorithm on a bigger graph we can use the following query to find nodes that belong to our k-spanning tree result. 
+When we run this algorithm on a bigger graph we can use the following query to find nodes that belong to our k-spanning tree result.
 
 .Find nodes that belong to our k-spanning tree result.
 [source,cypher]
 ----
 MATCH (n:Place)
-WITH n.partition as partition, count(*) as count 
+WITH n.partition as partition, count(*) as count
 WHERE count = k
-RETURN n 
+RETURN n
 ----
 
 == Example Usage
@@ -180,7 +180,7 @@ RETURN n
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.spanningTree(label:String, relationshipType:String, weightProperty:String, startNodeId:int, {writeProperty:String}) 
+CALL algo.spanningTree(label:String, relationshipType:String, weightProperty:String, startNodeId:int, {writeProperty:String})
 YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 ----
 
@@ -211,7 +211,7 @@ YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 .Running k-spanning tree algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.spanningTree.k*(label:String, relationshipType:String, weightProperty:String, startNodeId:int, k:int, {writeProperty:String}) 
+CALL algo.spanningTree.k*(label:String, relationshipType:String, weightProperty:String, startNodeId:int, k:int, {writeProperty:String})
 YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 ----
 
@@ -240,11 +240,11 @@ YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 |===
 
 
-== Versions 
+== Versions
 
 We support the following versions of the minimum weight spanning tree algorithm:
 
-* [x] undirected, weighted 
+* [x] undirected, weighted
 
 == References
 
@@ -274,7 +274,7 @@ A _Minimum Weight Spanning Tree_ is a acyclic undirected graph which consists of
 
 - [x] single threaded implementation
 - [x] tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] implement procedure
 - [x] benchmark on bigger graphs
 - [?] parallelization
@@ -287,8 +287,8 @@ A _Minimum Weight Spanning Tree_ is a acyclic undirected graph which consists of
 ## Data structured involved
 
 - `org.neo4j.graphalgo.core.utils.container.UndirectedTree` as container for efficient splitting and iterate
-- An int-based Fibonacci Heap priority queue. 
-- Container for visited state 
+- An int-based Fibonacci Heap priority queue.
+- Container for visited state
 
 ## ToDo
 

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -46,7 +46,7 @@ The MST algorithm only gives meaningful results when run on a graph where the re
 If the graph has no weights or all relationships have the same weight then any spanning tree is a minimum spanning tree.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Minimum Weight Spanning Tree algorithm sample
 
 image::mst.png[]
 

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -263,7 +263,7 @@ We support the following versions of the minimum weight spanning tree algorithm:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/81

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -36,7 +36,7 @@ where
 The PageRanks form a probability distribution over web pages, which means that the sum of all web pages' PageRanks will be one.
 // end::formula[]
 
-== When to use it / use-cases
+== Use-cases - when to use the PageRank algorithm
 
 // tag::use-case[]
 PageRank can be applied across a wide range of domains.
@@ -205,7 +205,7 @@ YIELD node, score - calculates page rank and streams results
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -267,7 +267,7 @@ We support the following versions of the pageRank algorithm:
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/78
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -56,7 +56,7 @@ It can help find doctors or providers that are behaving in an unusual manner and
 There are many more use cases which you can read about in David Gleich's https://arxiv.org/pdf/1407.5107.pdf[PageRank beyond the web^]
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the PageRank algorithm
 
 // tag::constraint[]
 There are some things to be aware of when using the Page Rank algorithm.

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -72,7 +72,7 @@ If you see unexpected results from running the algorithm it's worth doing some e
 You can read http://www.cs.princeton.edu/~chazelle/courses/BIB/pagerank.htm[The Google Pagerank Algorithm and How It Works^] to learn more.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== PageRank algorithm sample
 
 image::pagerank.png[]
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -118,7 +118,7 @@ As we might expect, the Home page has the highest PageRank because it has incomi
 We can also see that it's not only the number of incoming links that is important, but also the importance of the pages behind those links.
 // end::stream-sample-graph-explanation[]
 
-== Example Usage
+== Example usage
 
 We will run PageRank on Yelp's social network to find potential influencers.
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -12,7 +12,7 @@ More influential nodes will be visited more often.
 
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 PageRank is named after Google co-founder Larry Page and is used to rank websites in Google's search results.

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -97,7 +97,7 @@ include::scripts/single-shortest-path.cypher[tag=delta-stream-sample-graph]
 include::scripts/single-shortest-path.cypher[tag=delta-write-sample-graph]
 ----
 
-== Example Usage
+== Example usage
 
 
 == Syntax

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -18,7 +18,7 @@ He needed to find a problem and solution that people not familiar with computing
 He later implemented it for a slightly simplified transportation map of 64 cities in the Netherlands.
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Single Source Shortest Path algorithm
 
 // tag::use-case[]
 * Finding directions between physical locations.
@@ -55,13 +55,13 @@ include::scripts/single-shortest-path.cypher[tag=create-sample-graph]
 .Running algorithm and streaming results
 [source,cypher]
 ----
-include::scripts/single-shortest-path.cypher[tag=single-pair-stream-sample-graph]                
+include::scripts/single-shortest-path.cypher[tag=single-pair-stream-sample-graph]
 ----
 
-.Running algorithm and writing back results 
+.Running algorithm and writing back results
 [source,cypher]
 ----
-include::scripts/single-shortest-path.cypher[tag=single-pair-write-sample-graph]  
+include::scripts/single-shortest-path.cypher[tag=single-pair-write-sample-graph]
 ----
 
 // tag::single-pair-stream-sample-graph-result[]
@@ -88,13 +88,13 @@ We first go by rail from "A" to "D" at a cost of 50, from "D" to "E" by road for
 .Running algorithm and streaming results
 [source,cypher]
 ----
-include::scripts/single-shortest-path.cypher[tag=delta-stream-sample-graph] 
+include::scripts/single-shortest-path.cypher[tag=delta-stream-sample-graph]
 ----
 
-.Running algorithm and writing back results 
+.Running algorithm and writing back results
 [source,cypher]
 ----
-include::scripts/single-shortest-path.cypher[tag=delta-write-sample-graph] 
+include::scripts/single-shortest-path.cypher[tag=delta-write-sample-graph]
 ----
 
 == Example Usage
@@ -164,18 +164,18 @@ CALL algo.shortestPath.stream(startNode:Node, endNode:Node, weightProperty:Strin
 |===
 | name | type | description
 | nodeId | int | node id
-| cost | int | cost it takes to get from start node to specific node 
+| cost | int | cost it takes to get from start node to specific node
 |===
 
-== Versions 
+== Versions
 
 We support the following versions of the shortest path algorithms:
 
-* [x] directed, unweighted:  
+* [x] directed, unweighted:
 
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null
 
-* [x] directed, weighted 
+* [x] directed, weighted
 
 ** direction: 'OUTGOING' or INCOMING, weightProperty: 'cost'
 
@@ -183,7 +183,7 @@ We support the following versions of the shortest path algorithms:
 
 ** direction: 'BOTH', weightProperty: null
 
-* [x] undirected, weighted 
+* [x] undirected, weighted
 
 ** direction: 'BOTH', weightProperty: 'cost'
 
@@ -213,8 +213,8 @@ include::scripts/single-shortest-path.cypher[tag=cypher-loading]
 - parallel non-negative single source shortest path algorithm for weighted graphs
 - It can be tweaked using the delta-parameter which controls the grade of concurrency.
 - if initialized with an non-existing weight-property it will treat the graph as unweighted
- 
-`algo.shortestPaths` 
+
+`algo.shortestPaths`
 
 - specify start node, find the shortest paths to all other nodes
 - Dijkstra single source shortest path algorithm
@@ -243,13 +243,13 @@ ifdef::implementation[]
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/80
 
-A _Single Source Shortest Path_ algorithms calculates a path between a pair of nodes whose summed weights are minimal. A common algorithm used is Dijkstra. _All Pairs Shortest Path_ on the other hand calculates a shortest path forest containing all paths between the nodes in the graph. An algorithm to solve this is Floyd Warshall or Parallel Johnson's algorithm. 
+A _Single Source Shortest Path_ algorithms calculates a path between a pair of nodes whose summed weights are minimal. A common algorithm used is Dijkstra. _All Pairs Shortest Path_ on the other hand calculates a shortest path forest containing all paths between the nodes in the graph. An algorithm to solve this is Floyd Warshall or Parallel Johnson's algorithm.
 
 ## Progress
 
 - [x] single threaded implementation
 - [x] tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] implement procedure
 - [ ] benchmark on bigger graphs
 - [ ] parallelization
@@ -261,7 +261,7 @@ A _Single Source Shortest Path_ algorithms calculates a path between a pair of n
 
 ## Data structured involved
 
-- An int-based Fibonacci Heap which implements an efficient priority queue. 
+- An int-based Fibonacci Heap which implements an efficient priority queue.
 - Different Container for Costs / visited state / paths
 
 ## ToDo
@@ -290,8 +290,8 @@ Parallizing _All Pairs Shortest Path_ might be easy using Dijkstra on each threa
 - there may be more then one shortest path, algo returns only one
 - if initialized with an not-existing weight-property and a defaultWeight of 1.0 the resulting path is minimal in
  terms of count of nodes in the path.
- 
- 
+
+
 === algo.shortestPaths
 
 - Dijkstra single source shortest path algorithm

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -39,7 +39,7 @@ Dijkstra does not support negative weights.
 The algorithm assumes that adding a relationship to a path can never make a path shorter - an invariant that would be violated with negative weights.
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Single Source Shortest Path algorithm sample
 
 image::sssp.png[]
 

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -6,7 +6,7 @@ Dijkstra's algorithm is the most well known one in this category.
 SSSP is a real time graph algorithm and can be used as part of the normal user flow in a web or mobile application.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 Path finding has a long history and is considered to be one of the classical graph problems - it has been researched as far back as the 19th century.

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -32,7 +32,7 @@ It uses Dijkstra's algorithm to help detect changes in topology, such as link fa
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Single Source Shortest Path algorithm
 
 // tag::constraint[]
 Dijkstra does not support negative weights.

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -238,7 +238,7 @@ include::scripts/single-shortest-path.cypher[tag=cypher-loading]
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/80

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -31,7 +31,7 @@ The SCC algorithms can be used to find such groups and suggest the commonly like
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Strongly Connected Components algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -5,7 +5,7 @@ The _Strongly Connected Components_ (SCC) algorithm finds sets of connected node
 It is often used early in a graph analysis process to help us get an idea of how our graph is structured.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 SCC is one of the earliest graph algorithms and the first linear-time algorithm was described by Tarjan in 1972.

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -12,7 +12,7 @@ SCC is one of the earliest graph algorithms and the first linear-time algorithm 
 Decomposing a directed graph into its strongly connected components is a classic application of the depth-first search algorithm.
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Strongly Connected Components algorithm
 
 // tag::use-case[]
 
@@ -24,8 +24,8 @@ Read more in http://journals.plos.org/plosone/article/file?id=10.1371/journal.po
 Read more in https://dl.acm.org/citation.cfm?id=513803[Routing performance in the presence of unidirectional links in multihop wireless networks^]
 
 * _SCC_ algorithms can be used as a first step in many graph algorithms that work only on strongly connected graph.
-In social networks, a group of people are generally strongly connected (For example, students of a class or any other common place). 
-Many people in these groups generally like some common pages or play common games. 
+In social networks, a group of people are generally strongly connected (For example, students of a class or any other common place).
+Many people in these groups generally like some common pages or play common games.
 The SCC algorithms can be used to find such groups and suggest the commonly liked pages or games to the people in the group who have not yet liked commonly liked a page or played a game.
 
 
@@ -41,7 +41,7 @@ The SCC algorithms can be used to find such groups and suggest the commonly like
 
 image::strongly_connected_components.png[]
 
-A directed graph is strongly connected if there is a path between all pairs of vertices. 
+A directed graph is strongly connected if there is a path between all pairs of vertices.
 This algorithm treats the graph as directed, which means that the direction of the relationship is important.
 A strongly connected component only exists if there are relationships between nodes in both direction.
 
@@ -69,7 +69,7 @@ include::scripts/strongly-connected-components.cypher[tag=write-sample-graph]
 | Michael | 1
 | Charles | 0
 | Doug | 2
-| Mark | 2 
+| Mark | 2
 |===
 // end::stream-sample-graph-result[]
 
@@ -91,11 +91,11 @@ include::scripts/strongly-connected-components.cypher[tag=get-largest-component]
 .Running algorithm and writing back results
 [source,cypher]
 ----
-CALL algo.scc(label:String, relationship:String, 
-{write:true,partitionProperty:'partition',concurrency:4, graph:'heavy'}) 
+CALL algo.scc(label:String, relationship:String,
+{write:true,partitionProperty:'partition',concurrency:4, graph:'heavy'})
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 
-- finds strongly connected partitions and potentially writes back to the node as a property partition. 
+- finds strongly connected partitions and potentially writes back to the node as a property partition.
 ----
 
 .Parameters
@@ -126,7 +126,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 .Running algorithm and streaming results
 [source,cypher]
 ----
-CALL algo.scc.stream(label:String, relationship:String, {concurrency:4}) 
+CALL algo.scc.stream(label:String, relationship:String, {concurrency:4})
 YIELD nodeId, partition - yields a partition to each node id
 ----
 
@@ -149,7 +149,7 @@ YIELD nodeId, partition - yields a partition to each node id
 |===
 
 == Huge graph projection
- 
+
 If our projected graph contains more than 2 billion nodes or relationships, we need to use huge graph projection, as the default label and relationship-type projection has a limitation of 2 billion nodes and 2 billion relationships.
 Set `graph:'huge'` in the config.
 
@@ -182,7 +182,7 @@ include::scripts/strongly-connected-components.cypher[tag=cypher-loading]
 
 - also a *recursive* tarjan implementation
 
-`algo.scc.iterative` 
+`algo.scc.iterative`
 
 - *iterative* adaption of tarjan algorithm
 
@@ -218,7 +218,7 @@ _SCC_ is a class algorithms for finding groups of nodes where each node is direc
 - [x] implement procedure
 - [x] tests
 - [x] edge case tests
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] benchmark on bigger graphs
 - [x] parallelization
 - [x] evaluation

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -84,7 +84,7 @@ Charles ends up in his own component becuase there isn't an outgoing relationshi
 ----
 include::scripts/strongly-connected-components.cypher[tag=get-largest-component]
 ----
-== Example Usage
+== Example usage
 
 == Syntax
 

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -206,7 +206,7 @@ include::scripts/strongly-connected-components.cypher[tag=cypher-loading]
 ifdef::implementation[]
 // tag::implementation[]
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 // copied from: https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/97

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -37,7 +37,7 @@ The SCC algorithms can be used to find such groups and suggest the commonly like
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Strongly Connected Components algorithm sample
 
 image::strongly_connected_components.png[]
 

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -22,7 +22,7 @@ The computation of this score involves triangle counting.
 The transitivity coefficient of a graph, which is just three times the number of triangles divided by the number of triples in the graph is sometimes used.[2]
 // end::explanation[]
 
-== When to use it / use-cases
+== Use-cases - when to use the Triangle Counting / Clustering Coefficient algorithm
 
 // tag::use-case[]
 * Triangle count and clustering coefficient have been shown to be useful as features for classifying a given website as spam or non-spam content.
@@ -75,7 +75,7 @@ We can see that there are `KNOWS` triangles containing Will, Michael, and Chris,
 This means that everybody in the triangle knows each other.
 // end::stream-triples-explanation[]
 
-.counts the number of triangles a node is member of and writes it back. Returns total triangle count and average clustering coefficient of the given graph. 
+.counts the number of triangles a node is member of and writes it back. Returns total triangle count and average clustering coefficient of the given graph.
 [source,cypher]
 ----
 include::scripts/triangle-count.cypher[tag=triangle-write-sample-graph]
@@ -108,7 +108,7 @@ We learn that Michael is part of the most triangles, but it's Karin and Mark who
 == Example Usage
 
 In graph theory, a clustering coefficient is a measure of the degree to which nodes in a graph tend to cluster together.
-Evidence suggests that in most real-world networks, and in particular social networks, nodes tend to create tightly knit groups characterised by a relatively high density of ties; this likelihood tends to be greater than the average probability of a tie randomly established between two nodes.[4] 
+Evidence suggests that in most real-world networks, and in particular social networks, nodes tend to create tightly knit groups characterised by a relatively high density of ties; this likelihood tends to be greater than the average probability of a tie randomly established between two nodes.[4]
 
 We check if this holds true for Yelp's social network of friends.
 
@@ -117,11 +117,11 @@ We check if this holds true for Yelp's social network of friends.
 include::scripts/triangle-count.cypher[tag=triangle-write-yelp]
 ----
 
-Average clustering coefficient is 0.0523, which is really low for a social network. 
+Average clustering coefficient is 0.0523, which is really low for a social network.
 This indicates that groups of friends are not tightly knit together, but rather sparse.
 We can assume that users are not on Yelp for finding and creating friends, like for example Facebook, but rather something else, like finding good restaurant recommendations.
 
-   
+
 Local triangle count and clustering coefficient of nodes can be used as features in finding influencers in social networks.
 
 
@@ -180,11 +180,11 @@ YIELD nodeId, triangles - yield nodeId, number of triangles
 | triangles | int | number of triangles a node is member of
 |===
 
-.counts the number of triangles a node is member of and writes it back. Returns total triangle count and average clustering coefficient of the given graph. 
+.counts the number of triangles a node is member of and writes it back. Returns total triangle count and average clustering coefficient of the given graph.
 [source,cypher]
 ----
-CALL algo.triangleCount(label:String, relationship:String, 
-{concurrency:4, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'}) 
+CALL algo.triangleCount(label:String, relationship:String,
+{concurrency:4, write:true, writeProperty:'triangles', clusteringCoefficientProperty:'coefficient'})
 YIELD loadMillis, computeMillis, writeMillis, nodeCount, triangleCount, averageClusteringCoefficient
 ----
 
@@ -210,7 +210,7 @@ YIELD loadMillis, computeMillis, writeMillis, nodeCount, triangleCount, averageC
 | loadMillis | int | milliseconds for loading data
 | evalMillis | int | milliseconds for running the algorithm
 | writeMillis | int | milliseconds for writing result data back
-| triangleCount | int | number of triangles in the given graph. 
+| triangleCount | int | number of triangles in the given graph.
 | averageClusteringCoefficient | float | average clustering coefficient of the given graph
 
 
@@ -227,7 +227,7 @@ Set `graph:'cypher'` in the config.
 ----
 include::scripts/triangle-count.cypher[tag=cypher-loading]
 ----
-== Versions 
+== Versions
 
 We support the following versions of the triangle count algorithms:
 
@@ -264,7 +264,7 @@ ifdef::implementation[]
 - [x] tests
 - [ ] edge case tests
 - [x] implement procedure
-- [x] simple benchmark 
+- [x] simple benchmark
 - [x] benchmark on bigger graphs
 - [x] parallelization
 - [x] evaluation

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -105,7 +105,7 @@ include::scripts/triangle-count.cypher[tag=triangle-stream-sample-graph]
 We learn that Michael is part of the most triangles, but it's Karin and Mark who are the best at introducing their friends - all the people who know them know each other!
 // end::triangle-stream-sample-graph-explanation[]
 
-== Example Usage
+== Example usage
 
 In graph theory, a clustering coefficient is a measure of the degree to which nodes in a graph tend to cluster together.
 Evidence suggests that in most real-world networks, and in particular social networks, nodes tend to create tightly knit groups characterised by a relatively high density of ties; this likelihood tends to be greater than the average probability of a tie randomly established between two nodes.[4]

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -36,7 +36,7 @@ Find more in http://www.pnas.org/content/99/9/5825[Curvature of co-links uncover
 
 // end::use-case[]
 
-== Constraints / when not to use it
+== Constraints - when not to use the Triangle Counting / Clustering Coefficient algorithm
 
 // tag::constraint[]
 

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -256,7 +256,7 @@ ifdef::implementation[]
 // tag::implementation[]
 
 
-== Implementation Details
+== Implementation details
 
 :leveloffset: +1
 

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -42,7 +42,7 @@ Find more in http://www.pnas.org/content/99/9/5825[Curvature of co-links uncover
 
 // end::constraint[]
 
-== Algorithm explanation on simple sample graph
+== Triangle Counting / Clustering Coefficient algorithm sample
 
 image::triangle_count.png[]
 

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -5,7 +5,7 @@ Triangle counting is a community detection graph algorithm that is used to deter
 A triangle is a set of three nodes where each node has a relationship to all other nodes.
 // end::introduction[]
 
-== History, Explanation
+== History and explanation
 
 // tag::explanation[]
 


### PR DESCRIPTION
This PR standardizes the headers that re-appear in the documentation. 

Neo4j docs uses sentence-case for headers, so I have replaced the common headers with this format. I have also made the headers specific to the relevant algorithm wherever possible - this will assist with direct linking to use-cases, contraints, and samples.

Remaining headers, and adding anchor IDs to these headers will be handled in future PRs.