### PR TITLE
Standardize title format in the docs

### DIFF
--- a/doc/asciidoc/all-pairs-shortest-path.adoc
+++ b/doc/asciidoc/all-pairs-shortest-path.adoc
@@ -1,4 +1,4 @@
-= All Pairs Shortest Path
+= The All Pairs Shortest Path algorithm
 
 // tag::introduction[]
 _All Pairs Shortest Path_ (APSP) calculates the shortest (weighted) path between all pairs of nodes.

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -1,4 +1,4 @@
-= The A* Algorithm
+= The A* algorithm
 
 // tag::introduction[]
 

--- a/doc/asciidoc/betweenness-centrality-ra-brandes.adoc
+++ b/doc/asciidoc/betweenness-centrality-ra-brandes.adoc
@@ -1,11 +1,11 @@
-= Approximation of betweenness centrality
+= Approximation of Betweenness Centrality
 
 // tag::introduction[]
 As mentioned above, calculating the exact betweenness centrality on large graphs can be very time consuming.
 We might therefore choose to use an approximation algorithm that will run much quicker and still give us useful information.
 // end::introduction[]
 
-== RA-Brandes Algorithm
+== RA-Brandes algorithm
 
 // tag::explanation[]
 The RA-Brandes algorithm is the best known one for calculating an approximate score for betweenness centrality.

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -1,4 +1,4 @@
-= Betweenness Centrality
+= The Betweenness Centrality algorithm
 
 // tag::introduction[]
 _Betweenness Centrality_ is a way of detecting the amount of influence a node has over the flow of information in a graph.

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -1,4 +1,4 @@
-= Closeness Centrality
+= The Closeness Centrality algorithm
 
 // tag::introduction[]
 _Closeness Centrality_ is a way of detecting nodes that are able to spread information very efficiently through a graph.

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -1,4 +1,4 @@
-= Community detection: Connected Components
+= The Connected Components algorithm
 
 // tag::introduction[]
 The _Connected Components_ or _UnionFind_ algorithm finds sets of connected nodes in an undirected graph where each node is reachable from any other node in the same set.
@@ -54,7 +54,7 @@ image::connected_components.png[]
 include::scripts/connected-components.cypher[tag=create-sample-graph]
 ----
 
-=== Unweighted version:
+=== Unweighted version
 
 .Running algorithm and streaming results
 [source,cypher]
@@ -91,7 +91,7 @@ The first group contains Alice, Charles, and Bridget, while the second group con
 ----
 include::scripts/connected-components.cypher[tag=check-results-sample-graph]
 ----
-=== Weighted version:
+=== Weighted version
 
 If you define the property that holds the weight(weightProperty) and the threshold, it means the nodes are only connected, if the threshold on the weight of the relationship is high enough otherwise the relationship is thrown away.
 

--- a/doc/asciidoc/degree-centrality.adoc
+++ b/doc/asciidoc/degree-centrality.adoc
@@ -1,4 +1,4 @@
-= Degree Centrality
+= The Degree Centrality algorithm
 
 // tag::introduction[]
 Degree Centrality is the simplest of all the centrality algorithms.

--- a/doc/asciidoc/developer-api.adoc
+++ b/doc/asciidoc/developer-api.adoc
@@ -1,9 +1,9 @@
-= API 2 Model
+= API 2 model
 
-== Current Approach
+== Current approach
 
-Our current approach relies on buffering the graph data into local structures. 
-We've got different implementations, one (HeavyGraph) which consumes more memory but allows fast iteration on the Graph. 
+Our current approach relies on buffering the graph data into local structures.
+We've got different implementations, one (HeavyGraph) which consumes more memory but allows fast iteration on the Graph.
 The other one (LightGraph) has a more flexible memory model but performs not as well as the heavy one.
 Both versions take some time to load from Neo4j, the HeavyGraph can be loaded in parallel.
 
@@ -22,12 +22,12 @@ By default we currently load all aspects of the graph, that's why we waste some 
 ----
 
 
-== New Approach
+== New approach
 
-Loading the data takes time. 
-If we split the Graph into several interfaces and load only the needed ones, we end up with less import time. 
-This approach also allows us to define several implementations for an interface. 
-E.g. a `SingleRunNodeIterator` which is designed to run only once (and therefore does not need to buffer at all). 
+Loading the data takes time.
+If we split the Graph into several interfaces and load only the needed ones, we end up with less import time.
+This approach also allows us to define several implementations for an interface.
+E.g. a `SingleRunNodeIterator` which is designed to run only once (and therefore does not need to buffer at all).
 It would also ease the implementation of new operations like a `ConcurrentNodeIterator` (to pick batches of nodes for parallel evaluation) or an `AllRelationsIterator` (which doesn't need a node-id to start from).
 
 [ditaa]
@@ -63,10 +63,10 @@ It would also ease the implementation of new operations like a `ConcurrentNodeIt
                                            +-----------+
 ----
 
-The Diagram shows the basic idea. 
-Each Algorithm needs a set of data sources. 
+The Diagram shows the basic idea.
+Each Algorithm needs a set of data sources.
 _PageRank_ for example relies only on nodeIds and their degrees.
-While the underlying structure for  _UnionFind_  can be built just by iterating over all relations (or weighted relationships. depends on use case). 
+While the underlying structure for  _UnionFind_  can be built just by iterating over all relations (or weighted relationships. depends on use case).
 _kMeans_ on the other hand needs the result of a preceding algorithm to work.
 
 We can think of an algorithm as a component which needs several data sources as input and also is a
@@ -75,12 +75,12 @@ ones need precomputed data from previous steps.
 
 == Implementation
 
-We know every Algorithm needs one or more data sources to work. 
-The algorithm itself produces a result which might act as an input for the next one. 
+We know every Algorithm needs one or more data sources to work.
+The algorithm itself produces a result which might act as an input for the next one.
 Each algorithm also may need some kind of A Priori knowledge or configuration settings.
 
-Implementing this concept might be done using standard java oop. 
-The constructor of the implementation should take all needed data sources and a shared setup object. 
+Implementing this concept might be done using standard java oop.
+The constructor of the implementation should take all needed data sources and a shared setup object.
 Additional capabilities or requirements could later be added with Annotations (e.g. parallel, singlethreaded, one-time-use, ..) and the actual return type might just be the generic type of an interface.
 
 .Example algorithm interface:
@@ -119,8 +119,8 @@ public class PageRank implements Algorithm<PageRank.Result> {
 ----
 
 Up to now I would suggest hardcoded chains of Algorithms and no Capabilities/Requirements.
-The programmer can decide which implementation fits best for his algorithm. 
-Only the Importer (currently the GraphLoader) would check the constructor of the topmost algorithm to get a set of data sources it needs. 
+The programmer can decide which implementation fits best for his algorithm.
+Only the Importer (currently the GraphLoader) would check the constructor of the topmost algorithm to get a set of data sources it needs.
 It then loads the appropriate sources and initializes the algorithm.
 
 Later we might switch to some kind of object-graph-resolver which builds an optimal algorithm chain for one use case.

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -1,4 +1,4 @@
-= Harmonic Centrality
+= The Harmonic Centrality algorithm
 
 // tag::introduction[]
 Harmonic centrality (also known as 'valued centrality') is a variant of closeness centrality that was invented to solve the problem the original formula had when dealing with unconnected graphs.

--- a/doc/asciidoc/implementers.adoc
+++ b/doc/asciidoc/implementers.adoc
@@ -1,26 +1,26 @@
-= API Documentation
+= API documentation
 
-== Development Notes
+== Development notes
 
 NOTE: When implementing a procedure that yields any results (is not `void`) and writes back to the database, make sure to consume the `Result` after running the algorithm call!
 
-Algorithms are executed within a transaction, that is opened and closed by Cypher. 
+Algorithms are executed within a transaction, that is opened and closed by Cypher.
 The transaction is only marked successful if the results are consumed.
 Closing the Result directly will fail and rollback any open transactions and thus will revert all write-back operations.
 // StandardInternalExecutionResult#successful is only set to true _after_ the result has been consumed
 
 
-== The Model
+== The model
 
-The basic idea behind our model is to have a fast cache for the topology of the graph containing only relevant nodes, relations and in addition the weights. 
+The basic idea behind our model is to have a fast cache for the topology of the graph containing only relevant nodes, relations and in addition the weights.
 It implicitly maps (long) node-id's to an internal integer-id (32bit) in ascending order which ensures that no id gets bigger
-then the maximum node count. 
+then the maximum node count.
 This approach allows us to use primitive arrays as container for example.
 
-=== Graph Interface
+=== Graph interface
 
-The `Graph` interface specifies methods for iterating over all nodes of the graph as well as iterating over relationships of a given node in the form of `forEach...(..)`-methods. 
-The Graph knows the `nodeCount` and `degree` of each node and can map nodeId to internalId and vice versa. 
+The `Graph` interface specifies methods for iterating over all nodes of the graph as well as iterating over relationships of a given node in the form of `forEach...(..)`-methods.
+The Graph knows the `nodeCount` and `degree` of each node and can map nodeId to internalId and vice versa.
 // An Iterator is implemented for (single-)weighted and unweighted edges.
 
 
@@ -92,21 +92,21 @@ Relationships can be added in arbitrary order.
 
 `LightGraph`
 
-This implementation takes 3 times less heap due to a more intelligent memory layout. 
+This implementation takes 3 times less heap due to a more intelligent memory layout.
 The drawback is slightly higher evaluation time and that the data cannot be loaded in parallel (yet).
 
 `GraphView`
 
-The View is just a simple wrapper around the Neo4j Kernel API. 
+The View is just a simple wrapper around the Neo4j Kernel API.
 It has been implemented for tests and benchmarks baselines.
 
 == Import
 
-A fair amount of the work is to fetch the relevant data from Neo4j and import it into our model. 
-Fortunately we can use a multithreading approach to load the graph. 
+A fair amount of the work is to fetch the relevant data from Neo4j and import it into our model.
+Fortunately we can use a multithreading approach to load the graph.
 This is part of the current implementation.
 
-The abstract `GraphFactory` specifies a constructor and the `build` method. 
+The abstract `GraphFactory` specifies a constructor and the `build` method.
 It is responsible for creating the Graph using the Neo4j Kernel API.
 
 [ditaa]
@@ -138,4 +138,3 @@ final Graph graph = new GraphLoader( graphDatabaseAPI )
         .setThreadPool( .. )
         .load( FactoryImpl.class );
 ----
-

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -25,7 +25,7 @@ include::../../target/generated-documentation/org.neo4j.graphalgo.csv[]
 
 include::algorithms.adoc[leveloffset=1]
 
-== Implementers Section
+== Implementers section
 
 include::algo-procedures-api.adoc[leveloffset=2]
 
@@ -59,7 +59,7 @@ include::minimum-weight-spanning-tree.adoc[leveloffset=2,tags=implementation]
 
 include::single-shortest-path.adoc[leveloffset=2,tags=implementation]
 
-=== A* Algorithm
+=== A*
 
 include::astar.adoc[leveloffset=2,tags=implementation]
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -1,4 +1,4 @@
-= Community detection: Label Propagation
+= The Label Propagation algorithm
 
 // tag::introduction[]
 _Label Propagation_ (LPA) is a fast algorithm for finding communities in a graph.

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -1,4 +1,4 @@
-= Community detection: Louvain
+= The Louvain algorithm
 
 
 // tag::introduction[]

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -1,4 +1,4 @@
-= Minimum Weight Spanning Tree
+= The Minimum Weight Spanning Tree algorithm
 
 // tag::introduction[]
 The _Minimum Weight Spanning Tree_ (MST) starts from a given node and finds all its reachable nodes and the set of relationships that connect the nodes together with the minimum possible weight.
@@ -112,7 +112,7 @@ include::scripts/minimum-weight-spanning-tree.cypher[tag=write-sample-maxst-grap
 
 image::maxst_result.png[]
 
-=== k-Spanning tree
+=== K-Spanning tree
 
 Sometimes we want to limit the size of our spanning tree result as we are only interested in finding a smaller tree within our graph that does not span across all nodes.
 K-Spanning tree algorithm returns a tree with k nodes and k − 1 relationships.

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -1,4 +1,4 @@
-= PageRank
+= The PageRank algorithm
 
 // tag::introduction[]
 PageRank is widely recognized as a way of detecting influential nodes in a graph.

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -1,4 +1,4 @@
-= Single Source Shortest Path
+= The Single Source Shortest Path algorithm
 
 // tag::introduction[]
 The _Single Source Shortest Path_ (SSSP) algorithm calculates the shortest (weighted) path between a pair of nodes.
@@ -49,7 +49,7 @@ image::sssp.png[]
 include::scripts/single-shortest-path.cypher[tag=create-sample-graph]
 ----
 
-=== Dijkstra single source shortest path algorithm
+=== The Dijkstra Single Source Shortest Path algorithm
 
 
 .Running algorithm and streaming results

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -1,4 +1,4 @@
-= Community detection: Strongly Connected Components
+= The Strongly Connected Components algorithm
 
 // tag::introduction[]
 The _Strongly Connected Components_ (SCC) algorithm finds sets of connected nodes in a directed graph where each node is reachable in both directions from any other node in the same set.

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -1,4 +1,4 @@
-= Community detection: Triangle Counting / Clustering Coefficient
+= The Triangle Counting / Clustering Coefficient algorithm
 
 // tag::introduction[]
 Triangle counting is a community detection graph algorithm that is used to determine the number of triangles passing through each node in the graph.


### PR DESCRIPTION
This PR standardizes the titles that appear in the documentation.

Neo4j docs uses sentence-case for titles, so I have replaced the current titles with this format. I've also removed an inconsistent prefix (`Community detection:`) which was appearing on some of the algorithm titles.

Adding anchor IDs to these titles (and sub-headers) will be handled in a future PR.