### PR TITLE
Change maxDepth operator in sampled betweeneess

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/impl/betweenness/RABrandesBetweennessCentrality.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/betweenness/RABrandesBetweennessCentrality.java
@@ -195,7 +195,7 @@ public class RABrandesBetweennessCentrality extends Algorithm<RABrandesBetweenne
                 while (!queue.isEmpty()) {
                     int node = queue.removeFirst();
                     int nodeDepth = queue.removeFirst();
-                    if (nodeDepth > maxDepth) {
+                    if (nodeDepth - 1 > maxDepth ) {
                         continue;
                     }
                     stack.push(node);

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/betweenness/RABrandesBetweennessCentrality.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/betweenness/RABrandesBetweennessCentrality.java
@@ -195,7 +195,7 @@ public class RABrandesBetweennessCentrality extends Algorithm<RABrandesBetweenne
                 while (!queue.isEmpty()) {
                     int node = queue.removeFirst();
                     int nodeDepth = queue.removeFirst();
-                    if (nodeDepth - 1 > maxDepth ) {
+                    if (nodeDepth - 1 > maxDepth) {
                         continue;
                     }
                     stack.push(node);


### PR DESCRIPTION
This fixes the wrong operator for the maxDepth parameter of https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/524. Now the `maxDepth:1` will visit all nodes 1 hop away 