### PR TITLE
Remove the Implementers section from the docs build

### DIFF
--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -25,6 +25,7 @@ include::../../target/generated-documentation/org.neo4j.graphalgo.csv[]
 
 include::algorithms.adoc[leveloffset=1]
 
+ifndef::env-docs[]
 == Implementers section
 
 include::algo-procedures-api.adoc[leveloffset=2]
@@ -90,6 +91,8 @@ include::connected-components.adoc[leveloffset=2,tags=implementation]
 === Strongly Connected Components
 
 include::strongly-connected-components.adoc[leveloffset=2,tags=implementation]
+
+endif::env-docs[]
 
 ifdef::backend-html5[]
 ++++


### PR DESCRIPTION
Replaces #613 

Following discussion with @mneedham, this content is not required for general User Documentation purposes, and in some places is unfinished. 

As opposed to 613, this PR uses tagging to suppress the Implementers section from the documentation build only, and can be reinstated in the future if required. 