### PR TITLE
Add a TOC to docs homepage

### DIFF
--- a/doc/asciidoc/algorithms.adoc
+++ b/doc/asciidoc/algorithms.adoc
@@ -1,3 +1,4 @@
+[[algorithms]]
 = Algorithms
 
 Graph algorithms are used to compute metrics for graphs, nodes, or relationships.

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -6,15 +6,30 @@
 :toclevels: 2
 :env-docs: true
 
+[abstract]
+--
+This is the user guide for Neo4j Graph Algorithms version {docs-version}, authored by the Neo4j Team.
+--
+
+The guide covers the following areas:
+
+* <<introduction>> -- An introduction to Neo4j Graph Algorithms.
+* <<yelp-example>> -- An illustration of how to use graph algorithms on a social network of friends.
+* <<procedures>> -- A list of Neo4j Graph Algorithm procedures.
+* <<algorithms>> -- A detailed guide to each of the Neo4j Graph Algorithms, including use-cases and examples.
+
+
+[[introduction]]
 == Introduction
 
 include::../../readme.adoc[tags=readme,leveloffset=1]
 
-
+[[yelp-example]]
 == The Yelp example
 
 include::yelp-intro.adoc[leveloffset=1]
 
+[[procedures]]
 == Procedures
 
 [[table-all]]

--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -6,6 +6,8 @@
 :toclevels: 2
 :env-docs: true
 
+License: link:{common-license-page-uri}[Creative Commons 4.0]
+
 [abstract]
 --
 This is the user guide for Neo4j Graph Algorithms version {docs-version}, authored by the Neo4j Team.


### PR DESCRIPTION
This PR adds content to the Documentation landing page.

To enable the links in the TOC, this PR adds IDs to the following sections: 
* Introduction
* Yelp Example
* Procedures
* Algorithms

It does not include Implementers Section, which is to be suppressed in #638 

Note that Copyright information will be added to this page by @jjaderberg in a later PR