### PR TITLE
Change the "Versions" header to "Graph type support"

### DIFF
--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -117,7 +117,7 @@ include::scripts/astar.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the shortest path algorithms:
 

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -119,7 +119,7 @@ include::scripts/astar.cypher[tag=cypher-loading]
 
 == Graph type support
 
-The shortest path algorithms support the following graph types:
+The Shortest Path algorithms support the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null

--- a/doc/asciidoc/astar.adoc
+++ b/doc/asciidoc/astar.adoc
@@ -119,7 +119,7 @@ include::scripts/astar.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the shortest path algorithms:
+The shortest path algorithms support the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -126,7 +126,7 @@ include::scripts/betweenness-centrality.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the betweenness centrality algorithm:
 

--- a/doc/asciidoc/betweenness-centrality.adoc
+++ b/doc/asciidoc/betweenness-centrality.adoc
@@ -128,7 +128,7 @@ include::scripts/betweenness-centrality.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the betweenness centrality algorithm:
+The Betweenness Centrality algorithm supports the following graph types:
 
 * [x] directed, unweighted
 

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -217,7 +217,7 @@ include::scripts/closeness-centrality.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the closeness centrality algorithm:
 

--- a/doc/asciidoc/closeness-centrality.adoc
+++ b/doc/asciidoc/closeness-centrality.adoc
@@ -219,7 +219,7 @@ include::scripts/closeness-centrality.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the closeness centrality algorithm:
+The Closeness Centrality algorithm supports the following graph types:
 
 * [x] directed, unweighted
 * [ ] directed, weighted

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -188,7 +188,7 @@ include::scripts/harmonic-centrality.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the harmonic centrality algorithm:
 

--- a/doc/asciidoc/harmonic-centrality.adoc
+++ b/doc/asciidoc/harmonic-centrality.adoc
@@ -190,7 +190,7 @@ include::scripts/harmonic-centrality.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the harmonic centrality algorithm:
+The Harmonic Centrality algorithm supports the following graph types:
 
 * [*] undirected, unweighted
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -215,7 +215,7 @@ include::scripts/label-propagation.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the Label Propagation algorithm:
+The Label Propagation algorithm supports the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'INCOMING' or 'OUTGOING', weightProperty: null

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -213,7 +213,7 @@ include::scripts/label-propagation.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the Label Propagation algorithm:
 

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -223,6 +223,8 @@ include::scripts/louvain.cypher[tag=cypher-loading]
 
 == Graph type support
 
+The Louvain algorithm supports the following graph types:
+
 * [x] undirected, unweighted
 ** weightProperty: null
 * [x] undirected, weighted

--- a/doc/asciidoc/louvain.adoc
+++ b/doc/asciidoc/louvain.adoc
@@ -221,7 +221,7 @@ include::scripts/louvain.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 * [x] undirected, unweighted
 ** weightProperty: null

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -242,7 +242,7 @@ YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 
 == Graph type support
 
-We support the following versions of the Minimum Weight Spanning Tree algorithm:
+The Minimum Weight Spanning Tree algorithm supports the following graph type:
 
 * [x] undirected, weighted
 

--- a/doc/asciidoc/minimum-weight-spanning-tree.adoc
+++ b/doc/asciidoc/minimum-weight-spanning-tree.adoc
@@ -240,7 +240,7 @@ YIELD loadMillis, computeMillis, writeMillis, effectiveNodeCount
 |===
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the Minimum Weight Spanning Tree algorithm:
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -236,7 +236,7 @@ include::scripts/pagerank.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the PageRank algorithm:
 

--- a/doc/asciidoc/pagerank.adoc
+++ b/doc/asciidoc/pagerank.adoc
@@ -238,7 +238,7 @@ include::scripts/pagerank.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the PageRank algorithm:
+The PageRank algorithm supports the following graph types:
 
 * [x] directed, unweighted
 

--- a/doc/asciidoc/shortest-path.adoc
+++ b/doc/asciidoc/shortest-path.adoc
@@ -170,7 +170,7 @@ CALL algo.shortestPath.stream(startNode:Node, endNode:Node, weightProperty:Strin
 
 == Graph type support
 
-We support the following versions of the shortest path algorithms:
+The shortest path algorithms support the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null

--- a/doc/asciidoc/shortest-path.adoc
+++ b/doc/asciidoc/shortest-path.adoc
@@ -168,7 +168,7 @@ CALL algo.shortestPath.stream(startNode:Node, endNode:Node, weightProperty:Strin
 |===
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the shortest path algorithms:
 

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -154,7 +154,7 @@ YIELD nodeId, cost
 |===
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the shortest path algorithms:
 

--- a/doc/asciidoc/single-shortest-path.adoc
+++ b/doc/asciidoc/single-shortest-path.adoc
@@ -156,7 +156,7 @@ YIELD nodeId, cost
 
 == Graph type support
 
-We support the following versions of the shortest path algorithms:
+The shortest path algorithms support the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -231,7 +231,7 @@ include::scripts/triangle-count.cypher[tag=cypher-loading]
 
 == Graph type support
 
-We support the following versions of the triangle count algorithms:
+The Triangle Count algorithms support the following graph type:
 
 * [x] undirected, unweighted
 

--- a/doc/asciidoc/triangleCount.adoc
+++ b/doc/asciidoc/triangleCount.adoc
@@ -229,7 +229,7 @@ include::scripts/triangle-count.cypher[tag=cypher-loading]
 ----
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the triangle count algorithms:
 

--- a/doc/asciidoc/yens-k-shortest-paths.adoc
+++ b/doc/asciidoc/yens-k-shortest-paths.adoc
@@ -116,7 +116,7 @@ YIELD resultCount, loadMillis, evalMillis, writeMillis
 |===
 
 
-== Versions
+== Graph type support
 
 We support the following versions of the shortest path algorithms:
 

--- a/doc/asciidoc/yens-k-shortest-paths.adoc
+++ b/doc/asciidoc/yens-k-shortest-paths.adoc
@@ -118,7 +118,7 @@ YIELD resultCount, loadMillis, evalMillis, writeMillis
 
 == Graph type support
 
-We support the following versions of the shortest path algorithms:
+The Shortest Path algorithms support the following graph types:
 
 * [x] directed, unweighted:
 ** direction: 'OUTGOING' or INCOMING, weightProperty: null


### PR DESCRIPTION
Each algo has a header called "Versions", which doesn't make much sense. This PR changes these to "Graph type support", and adds the following text:

```The XXXX algorithm supports the following graph types:```