### PR TITLE
store weights along with relationships for Yens k-shortest path

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/KShortestPathsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/KShortestPathsProc.java
@@ -50,6 +50,8 @@ public class KShortestPathsProc {
 
     public static final String DEFAULT_TARGET_PROPERTY = "PATH_";
     public static final String PREFIX_IDENTIFIER = "writePropertyPrefix";
+    public static final String REL_TYPE_PROPERTY_IDENTIFIER = "writeRelationshipTypeProperty";
+    public static final String DEFAULT_RELATIONSHIP_PROPERTY = "weight";
 
     @Context
     public GraphDatabaseAPI api;
@@ -118,7 +120,9 @@ public class KShortestPathsProc {
                 new WeightedPathExporter(api,
                         Pools.DEFAULT,
                         graph,
-                        configuration.getString(PREFIX_IDENTIFIER, DEFAULT_TARGET_PROPERTY))
+                        graph,
+                        configuration.getString(PREFIX_IDENTIFIER, DEFAULT_TARGET_PROPERTY),
+                        configuration.getString(REL_TYPE_PROPERTY_IDENTIFIER, DEFAULT_RELATIONSHIP_PROPERTY))
                         .export(algorithm.getPaths());
             }
         }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/yens/WeightedPathExporter.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/yens/WeightedPathExporter.java
@@ -1,12 +1,14 @@
 package org.neo4j.graphalgo.impl.yens;
 
 import org.neo4j.graphalgo.api.IdMapping;
+import org.neo4j.graphalgo.api.RelationshipWeights;
 import org.neo4j.graphalgo.core.utils.ExceptionUtil;
 import org.neo4j.graphalgo.core.utils.ParallelUtil;
 import org.neo4j.graphalgo.core.utils.Pointer;
 import org.neo4j.graphalgo.core.utils.StatementApi;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.values.storable.Values;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -20,17 +22,23 @@ import java.util.stream.Collectors;
 public class WeightedPathExporter extends StatementApi {
 
     private final IdMapping idMapping;
+    private final RelationshipWeights relationshipWeights;
     private final String relPrefix;
     private final ExecutorService executorService;
+    private final String propertyName;
 
     public WeightedPathExporter(GraphDatabaseAPI api,
                                 ExecutorService executorService,
                                 IdMapping idMapping,
-                                String relPrefix) {
+                                RelationshipWeights relationshipWeights,
+                                String relPrefix,
+                                String propertyName) {
         super(api);
         this.executorService = executorService;
         this.idMapping = idMapping;
+        this.relationshipWeights = relationshipWeights;
         this.relPrefix = relPrefix;
+        this.propertyName = propertyName;
     }
 
     /**
@@ -45,19 +53,24 @@ public class WeightedPathExporter extends StatementApi {
         }
     }
 
-    private void export(String property, WeightedPath path) {
+    private void export(String relationshipType, String propertyName, WeightedPath path) {
         applyInTransaction(statement -> {
-            final int relId = statement.tokenWrite().relationshipTypeGetOrCreateForName(property);
+            final int relId = statement.tokenWrite().relationshipTypeGetOrCreateForName(relationshipType);
             if (relId == -1) {
                 throw new IllegalStateException("no write property id is set");
             }
             path.forEachEdge((s, t) -> {
                 try {
-                    statement.dataWrite().relationshipCreate(
+                    long relationshipId = statement.dataWrite().relationshipCreate(
                             idMapping.toOriginalNodeId(s),
                             relId,
                             idMapping.toOriginalNodeId(t)
                     );
+
+                    statement.dataWrite().relationshipSetProperty(
+                            relationshipId,
+                            getOrCreatePropertyId(propertyName),
+                            Values.doubleValue(relationshipWeights.weightOf(s, t)));
                 } catch (KernelException e) {
                     ExceptionUtil.throwKernelException(e);
                 }
@@ -67,12 +80,18 @@ public class WeightedPathExporter extends StatementApi {
 
     }
 
+    private int getOrCreatePropertyId(String propertyName) {
+        return applyInTransaction(stmt -> stmt
+                .tokenWrite()
+                .propertyKeyGetOrCreateForName(propertyName));
+    }
+
     private void writeSequential(List<WeightedPath> paths) {
         final Pointer.IntPointer counter = Pointer.wrap(0);
         paths.stream()
                 .sorted(WeightedPath.comparator())
                 .forEach(path ->
-                        export(String.format("%s%d", relPrefix, counter.v++), path));
+                        export(String.format("%s%d", relPrefix, counter.v++), propertyName, path));
     }
 
     private void writeParallel(List<WeightedPath> paths) {
@@ -80,7 +99,7 @@ public class WeightedPathExporter extends StatementApi {
         final List<Runnable> tasks = paths.stream()
                 .sorted(WeightedPath.comparator())
                 .map(path -> (Runnable) () ->
-                        export(String.format("%s%d", relPrefix, counter.v++), path))
+                        export(String.format("%s%d", relPrefix, counter.v++), propertyName, path))
                 .collect(Collectors.toList());
         ParallelUtil.run(tasks, executorService);
     }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/YensKShortestPathsRelationshipCostsTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/YensKShortestPathsRelationshipCostsTest.java
@@ -1,0 +1,72 @@
+package org.neo4j.graphalgo.algo;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.graphalgo.KShortestPathsProc;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Graph:
+ * <p>
+ * (0)
+ * /  |  \
+ * (4)--(5)--(1)
+ * \  /  \ /
+ * (3)---(2)
+ *
+ * @author mknblch
+ */
+public class YensKShortestPathsRelationshipCostsTest {
+
+    @ClassRule
+    public static ImpermanentDatabaseRule DB = new ImpermanentDatabaseRule();
+
+    @BeforeClass
+    public static void setupGraph() throws KernelException {
+
+        final String cypher =
+                "CREATE (a:Node {name:'a'})\n" +
+                        "CREATE (b:Node {name:'b'})\n" +
+                        "CREATE (c:Node {name:'c'})\n" +
+                        "CREATE" +
+                        " (a)-[:TYPE {cost:3.0}]->(b),\n" +
+                        " (b)-[:TYPE {cost:2.0}]->(c)";
+
+        DB.execute(cypher);
+        DB.resolveDependency(Procedures.class).registerProcedure(KShortestPathsProc.class);
+    }
+
+    @Test
+    public void test() {
+        final String cypher =
+                "MATCH (c:Node{name:'c'}), (a:Node{name:'a'}) " +
+                "CALL algo.kShortestPaths(c, a, 1, 'cost') " +
+                "YIELD resultCount RETURN resultCount";
+
+        DB.execute(cypher).accept(row -> {
+            assertEquals(1, row.getNumber("resultCount").intValue());
+            return true;
+        });
+
+        final String shortestPathsQuery = "MATCH p=(:Node {name: $one})-[r:PATH_0*]->(:Node {name: $two})\n" +
+                "UNWIND relationships(p) AS pair\n" +
+                "return sum(pair.weight) AS distance";
+
+        DB.execute(shortestPathsQuery, MapUtil.map("one", "c", "two", "a")).accept(row -> {
+            assertEquals(5.0, row.getNumber("distance").doubleValue(), 0.01);
+            return true;
+        });
+
+
+    }
+}

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/YensKShortestPathsTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/YensKShortestPathsTest.java
@@ -7,9 +7,13 @@ import org.neo4j.graphalgo.KShortestPathsProc;
 import org.neo4j.graphalgo.LouvainProc;
 import org.neo4j.graphalgo.impl.yens.YensKShortestPaths;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
@@ -76,5 +80,29 @@ public class YensKShortestPathsTest {
             assertEquals(39, DB.getAllRelationships().stream().count());
             transaction.success();
         }
+
+        Map<String, Double> combinations = new HashMap<>();
+        combinations.put("PATH_0", 3.0);
+        combinations.put("PATH_1", 3.0);
+        combinations.put("PATH_2", 4.0);
+        combinations.put("PATH_3", 4.0);
+        combinations.put("PATH_4", 5.0);
+        combinations.put("PATH_5", 5.0);
+        combinations.put("PATH_6", 5.0);
+        combinations.put("PATH_7", 8.0);
+        combinations.put("PATH_8", 8.0);
+
+        for (String relationshipType : combinations.keySet()) {
+            final String shortestPathsQuery = String.format("MATCH p=(:Node {name: $one})-[r:%s*]->(:Node {name: $two})\n" +
+                    "UNWIND relationships(p) AS pair\n" +
+                    "return sum(pair.weight) AS distance", relationshipType);
+
+            DB.execute(shortestPathsQuery, MapUtil.map("one", "a", "two", "f")).accept(row -> {
+                assertEquals(combinations.get(relationshipType), row.getNumber("distance").doubleValue(), 0.01);
+                return true;
+            });
+        }
+
+
     }
 }


### PR DESCRIPTION
It makes it much easier to consume the output of Yens k-shortest path if we also store the distance on the generated relationships