### PR TITLE
Add algo.version() function

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/Version.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/Version.java
@@ -1,0 +1,12 @@
+package org.neo4j.graphalgo;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.UserFunction;
+
+public class Version {
+    @UserFunction("algo.version")
+    @Description("RETURN algo.version() | return the current graph algorithms installed version")
+    public String version() {
+        return ""+Version.class.getPackage().getImplementationVersion();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,19 @@
                     </includes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>
+                                true
+                            </addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/VersionTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/VersionTest.java
@@ -1,0 +1,66 @@
+package org.neo4j.graphalgo.algo;
+
+/**
+ * Copyright (c) 2018 "Neo4j, Inc." <http://neo4j.com>
+ *
+ * This file is part of Neo4j Graph Algorithms <http://github.com/neo4j-contrib/neo4j-graph-algorithms>.
+ *
+ * Neo4j Graph Algorithms is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphalgo.TestDatabaseCreator;
+import org.neo4j.graphalgo.Version;
+import org.neo4j.graphdb.Result;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public final class VersionTest {
+    private static GraphDatabaseAPI api;
+
+    @BeforeClass
+    public static void setup() throws KernelException {
+        api = TestDatabaseCreator.createTestDatabase();
+
+        api.getDependencyResolver()
+                .resolveDependency(Procedures.class)
+                .registerBuiltInFunctions(Version.class);
+    }
+
+    @AfterClass
+    public static void shutdownGraph() throws Exception {
+        api.shutdown();
+    }
+
+    @Test
+    public void testVersion() throws Exception {
+        final String cypher = "RETURN algo.version() as version";
+
+        Result res = api.execute(cypher);
+        Map<String,Object> row = res.next();
+
+        assertFalse(res.hasNext());
+        System.out.println(row);
+        System.out.println(VersionTest.class.getPackage().getImplementationVersion());
+        System.out.println(VersionTest.class.getPackage());
+        assertEquals(row.get("version"), ""+VersionTest.class.getPackage().getImplementationVersion());
+    }
+}


### PR DESCRIPTION
This PR adds a really simple `RETURN algo.version()` function that returns the same version as is defined in the POM.  

The implementation is mostly borrowed from APOC, which does the same thing.

The reason why this feature is useful is that calling it:
- Verifies that algos are installed in a neo4j instance
- Doesn't require any computation overhead
- Provides useful compatibility information for later uses (i.e. only version >= X has the FooAlgorithm)

For cloud packaging, I use this technique with APOC, and it'd be nice to have in algos too since it's so trivial to implement.

Notes for consideration:
- The POM changes are what annotates the JAR with the data that permits fetching package implementation.
- The unit test is kinda/sorta bogus.  It verifies that the function is in place, but doesn't do much useful beyond that.  This is because the package annotations are only available at runtime in an actual JAR.   As a result, the value returned in the unit test (when run locally) will be "null".  This isn't an error, it's a lifecycle issue.   I tested algos for real by loading them into a Neo4j Desktop instance, running `RETURN algo.version()` which gave the right result when packaged as a JAR.