### PR TITLE
Fix balancedTriads.stream description

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/BalancedTriadsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/BalancedTriadsProc.java
@@ -54,7 +54,7 @@ public class BalancedTriadsProc {
 
     @Procedure("algo.balancedTriads.stream")
     @Description("CALL algo.balancedTriads.stream(label, relationship, {concurrency:8}) " +
-            "YIELD nodeId, balancedTriadCount, unbalancedTriadCount")
+            "YIELD nodeId, balanced, unbalanced")
     public Stream<HugeBalancedTriads.Result> balancedTriadsStream(
             @Name(value = "label", defaultValue = "") String label,
             @Name(value = "relationship", defaultValue = "") String relationship,


### PR DESCRIPTION
Fixing the description as the procedure actually returns balanced and unbalanced values as defined in https://github.com/neo4j-contrib/neo4j-graph-algorithms/blob/3.4/algo/src/main/java/org/neo4j/graphalgo/impl/triangle/HugeBalancedTriads.java#L126

I changed the description and not the name of results to be more aligned with the write-back version.

```
public static final String DEFAULT_BALANCED_PROPERTY = "balanced";
public static final String DEFAULT_UNBALANCED_PROPERTY = "unbalanced";
```