### PR TITLE
Ensure that documentation includes new categories

### DIFF
--- a/doc/asciidoc/index.adoc
+++ b/doc/asciidoc/index.adoc
@@ -21,8 +21,9 @@ The guide covers the following areas:
 * <<algorithms-centrality>> -- A detailed guide to each of the centrality algorithms, including use-cases and examples.
 * <<algorithms-community>> -- A detailed guide to each of the community detection algorithms, including use-cases and examples.
 * <<algorithms-path-finding>> -- A detailed guide to each of the path finding algorithms, including use-cases and examples.
-* <<algorithms-preprocessing>> -- A detailed guide to each of the preprocessing functions and procedures.
 * <<algorithms-similarity>> -- A detailed guide to each of the similarity algorithms, including use-cases and examples.
+* <<algorithms-preprocessing>> -- A detailed guide to each of the preprocessing functions and procedures.
+
 
 [[introduction]]
 == Introduction
@@ -64,8 +65,9 @@ include::../../target/generated-documentation/documentation.csv[]
 include::algorithms-centrality.adoc[leveloffset=1]
 include::algorithms-community.adoc[leveloffset=1]
 include::algorithms-path-finding.adoc[leveloffset=1]
-include::algorithms-preprocessing.adoc[leveloffset=1]
 include::algorithms-similarity.adoc[leveloffset=1]
+include::algorithms-preprocessing.adoc[leveloffset=1]
+
 
 ifndef::env-docs[]
 == Implementers section

--- a/doc/docbook/content-map.xml
+++ b/doc/docbook/content-map.xml
@@ -7,6 +7,7 @@
     </d:tocentry>
     <d:tocentry linkend="procedures"><?dbhtml filename="procedures/index.html"?>
     </d:tocentry>
+
     <d:tocentry linkend="algorithms-centrality"><?dbhtml filename="algorithms/centrality/index.html"?>
       <d:tocentry linkend="algorithms-pagerank"><?dbhtml filename="algorithms/page-rank/index.html"?>
       </d:tocentry>
@@ -47,6 +48,21 @@
       <d:tocentry linkend="algorithms-random-walk"><?dbhtml filename="algorithms/random-walk/index.html"?>
       </d:tocentry>
     </d:tocentry>
+
+    <d:tocentry linkend="algorithms-similarity"><?dbhtml filename="algorithms/similarity/index.html"?>
+      <d:tocentry linkend="algorithms-similarity-jaccard"><?dbhtml filename="algorithms/similarity-jaccard/index.html"?>
+      </d:tocentry>
+      <d:tocentry linkend="algorithms-similarity-cosine"><?dbhtml filename="algorithms/similarity-cosine/index.html"?>
+      </d:tocentry>
+      <d:tocentry linkend="algorithms-similarity-euclidean"><?dbhtml filename="algorithms/similarity-euclidean/index.html"?>
+      </d:tocentry>
+    </d:tocentry>
+
+    <d:tocentry linkend="algorithms-preprocessing"><?dbhtml filename="algorithms/preprocessing/index.html"?>
+      <d:tocentry linkend="algorithms-one-hot-encoding"><?dbhtml filename="algorithms/one-hot-encoding/index.html"?>
+      </d:tocentry>
+    </d:tocentry>
+    
   </d:tocentry>
 </d:toc>
 <!-- vim: set ts=2 sw=2: -->


### PR DESCRIPTION
The new categories (Similarity and Preprocessing) were inconsistent in the order of presentation, and needed to be added to the content map.