### PR TITLE
Enable to use only topK param with similarity algos

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/similarity/CosineProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/similarity/CosineProc.java
@@ -68,7 +68,7 @@ public class CosineProc extends SimilarityProc {
         SimilarityComputer<WeightedInput> computer = similarityComputer(skipValue);
         Stream<SimilarityResult> stream = generateStream(configuration, inputs, similarityCutoff, topN, topK, computer);
 
-        boolean write = configuration.isWriteFlag(false) && similarityCutoff > 0.0;
+        boolean write = configuration.isWriteFlag(false) && (similarityCutoff > 0.0 || topK > 0);
         return writeAndAggregateResults(configuration, stream, inputs.length, write, "SIMILAR");
     }
 


### PR DESCRIPTION
This is an option how to allow users to use only topK parameter as for example:

`CALL algo.similarity.cosine.stream(data, {topK:1})`

Idea came from https://github.com/neo4j-contrib/neo4j-graph-algorithms/issues/729 and https://github.com/neo4j-contrib/neo4j-graph-algorithms/pull/730 and this PR is a nice and clean solution,
which I think is improves user experience and causes less confusion with the user. On the other hand, there are cases where dissimilar relationships would get written back because we don't limit it anymore when providing topK param. This should be more of a problem with smaller datasets and with large datasets this won't usually happen in my experience.

What are your thoughts @mneedham @jexp?

Will add the code to all similarity algos if this is ok.
