### PR TITLE
Add Balanced Triads to the list of algos on the Readme

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -49,6 +49,7 @@ These algorithms evaluate how a group is clustered or partitioned, as well as it
 * <<algorithms-connected-components, Connected Components>> (`algo.unionFind`)
 * <<algorithms-strongly-connected-components, Strongly Connected Components>> (`algo.scc`)
 * <<algorithms-triangle-count-clustering-coefficient, Triangle Counting / Clustering Coefficient>> (`algo.triangleCount`)
+* <<algorithms-balanced-triads, Balanced Triads>> (`algo.balancedTriads`)
 
 
 === Path finding


### PR DESCRIPTION
Missing from 3.4 onwards