### PR TITLE
3.4 writeproperty

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
@@ -74,13 +74,24 @@ public final class LabelPropagationProc {
     public Stream<LabelPropagationStats> labelPropagation(
             @Name(value = "label", defaultValue = "") String label,
             @Name(value = "relationship", defaultValue = "") String relationshipType,
-            @Name(value = "direction", defaultValue = "OUTGOING") String directionName,
-            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+            @Name(value = "config", defaultValue="null") Object directionOrConfig,
+            @Name(value = "deprecatedConfig", defaultValue = "{}") Map<String, Object> config) {
+        Map<String, Object> rawConfig = config;
+        if (directionOrConfig == null) {
+            if (!config.isEmpty()) {
+                directionOrConfig = "OUTGOING";
+            }
+        } else if (directionOrConfig instanceof Map) {
+            rawConfig = (Map<String, Object>) directionOrConfig;
+        }
 
-        final ProcedureConfiguration configuration = ProcedureConfiguration.create(config)
+        final ProcedureConfiguration configuration = ProcedureConfiguration.create(rawConfig)
                 .overrideNodeLabelOrQuery(label)
-                .overrideRelationshipTypeOrQuery(relationshipType)
-                .overrideDirection(directionName);
+                .overrideRelationshipTypeOrQuery(relationshipType);
+
+        if(directionOrConfig instanceof String) {
+            configuration.overrideDirection((String) directionOrConfig);
+        }
 
         final int iterations = configuration.getIterations(DEFAULT_ITERATIONS);
         final int batchSize = configuration.getBatchSize();

--- a/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/LabelPropagationProc.java
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 public final class LabelPropagationProc {
 
     public static final String CONFIG_WEIGHT_KEY = "weightProperty";
+    public static final String CONFIG_WRITE_KEY = "writeProperty";
     public static final String CONFIG_PARTITION_KEY = "partitionProperty";
     public static final Integer DEFAULT_ITERATIONS = 1;
     public static final Boolean DEFAULT_WRITE = Boolean.TRUE;
@@ -85,11 +86,13 @@ public final class LabelPropagationProc {
         final int batchSize = configuration.getBatchSize();
         final int concurrency = configuration.getConcurrency();
         final String partitionProperty = configuration.getString(CONFIG_PARTITION_KEY, DEFAULT_PARTITION_KEY);
+        final String writeProperty = configuration.get(CONFIG_WRITE_KEY, CONFIG_PARTITION_KEY, DEFAULT_PARTITION_KEY);
         final String weightProperty = configuration.getString(CONFIG_WEIGHT_KEY, DEFAULT_WEIGHT_KEY);
 
         LabelPropagationStats.Builder stats = new LabelPropagationStats.Builder()
                 .iterations(iterations)
                 .partitionProperty(partitionProperty)
+                .writeProperty(writeProperty)
                 .weightProperty(weightProperty);
 
         GraphLoader graphLoader = graphLoader(configuration, partitionProperty, weightProperty, createPropertyMappings(partitionProperty, weightProperty));
@@ -109,9 +112,9 @@ public final class LabelPropagationProc {
         }
 
         final int[] labels = compute(direction, iterations, batchSize, concurrency, graph, stats);
-        if (configuration.isWriteFlag(DEFAULT_WRITE) && partitionProperty != null) {
+        if (configuration.isWriteFlag(DEFAULT_WRITE) && writeProperty != null) {
             stats.withWrite(true);
-            write(concurrency, partitionProperty, graph, labels, stats);
+            write(concurrency, writeProperty, graph, labels, stats);
         }
 
         return Stream.of(stats.build(graph.nodeCount(), l -> (long) labels[(int) l]));

--- a/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
@@ -125,7 +125,7 @@ public class StronglyConnectedComponentsProc {
         final int[] connectedComponents = tarjan.getConnectedComponents();
         if (configuration.isWriteFlag()) {
             builder.withWrite(true);
-            String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
+            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
             builder.withPartitionProperty(partitionProperty);
 
             builder.timeWrite(() -> {
@@ -180,7 +180,7 @@ public class StronglyConnectedComponentsProc {
 
         if (configuration.isWriteFlag()) {
             builder.withWrite(true);
-            String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
+            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
             builder.withPartitionProperty(partitionProperty);
 
             builder.timeWrite(() -> Exporter
@@ -383,7 +383,7 @@ public class StronglyConnectedComponentsProc {
             multistep.release();
             builder.timeWrite(() -> {
                 builder.withWrite(true);
-                String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
+                String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
                 builder.withPartitionProperty(partitionProperty);
 
                 Exporter

--- a/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/StronglyConnectedComponentsProc.java
@@ -51,7 +51,8 @@ import java.util.stream.Stream;
  */
 public class StronglyConnectedComponentsProc {
 
-    public static final String CONFIG_WRITE_PROPERTY = "partitionProperty";
+    public static final String CONFIG_WRITE_PROPERTY = "writeProperty";
+    public static final String CONFIG_OLD_WRITE_PROPERTY = "partitionProperty";
     public static final String CONFIG_CLUSTER = "partition";
 
     @Context
@@ -124,7 +125,7 @@ public class StronglyConnectedComponentsProc {
         final int[] connectedComponents = tarjan.getConnectedComponents();
         if (configuration.isWriteFlag()) {
             builder.withWrite(true);
-            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_CLUSTER);
+            String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
             builder.withPartitionProperty(partitionProperty);
 
             builder.timeWrite(() -> {
@@ -179,7 +180,7 @@ public class StronglyConnectedComponentsProc {
 
         if (configuration.isWriteFlag()) {
             builder.withWrite(true);
-            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_CLUSTER);
+            String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
             builder.withPartitionProperty(partitionProperty);
 
             builder.timeWrite(() -> Exporter
@@ -261,8 +262,8 @@ public class StronglyConnectedComponentsProc {
 
         if (configuration.isWriteFlag()) {
             builder.withWrite(true);
-            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_CLUSTER);
-            builder.withPartitionProperty(partitionProperty);
+            String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
+            builder.withPartitionProperty(partitionProperty).withWriteProperty(partitionProperty);
 
             builder.timeWrite(() -> write(configuration, graph, terminationFlag, tarjan, partitionProperty));
         }
@@ -382,7 +383,7 @@ public class StronglyConnectedComponentsProc {
             multistep.release();
             builder.timeWrite(() -> {
                 builder.withWrite(true);
-                String partitionProperty = configuration.get(CONFIG_WRITE_PROPERTY, CONFIG_CLUSTER);
+                String partitionProperty = configuration.get(CONFIG_OLD_WRITE_PROPERTY, CONFIG_CLUSTER);
                 builder.withPartitionProperty(partitionProperty);
 
                 Exporter

--- a/algo/src/main/java/org/neo4j/graphalgo/results/LabelPropagationStats.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/results/LabelPropagationStats.java
@@ -44,7 +44,7 @@ public class LabelPropagationStats {
             false,
             false,
             "<empty>",
-            "<empty>");
+            "<empty>", "<empty>");
 
     public final long loadMillis;
     public final long computeMillis;
@@ -70,10 +70,11 @@ public class LabelPropagationStats {
     public final String weightProperty;
     public final boolean write;
     public final String partitionProperty;
+    public final String writeProperty;
 
     public LabelPropagationStats(long loadMillis, long computeMillis, long postProcessingMillis, long writeMillis, long nodes,
                                  long communityCount, long p100, long p99, long p95, long p90, long p75, long p50, long p25, long p10, long p5, long p1, long iterations, boolean write, boolean didConverge,
-                                 String weightProperty, String partitionProperty) {
+                                 String weightProperty, String partitionProperty, String writeProperty) {
         this.loadMillis = loadMillis;
         this.computeMillis = computeMillis;
         this.postProcessingMillis = postProcessingMillis;
@@ -95,6 +96,7 @@ public class LabelPropagationStats {
         this.didConverge = didConverge;
         this.weightProperty = weightProperty;
         this.partitionProperty = partitionProperty;
+        this.writeProperty = writeProperty;
     }
 
 
@@ -104,6 +106,7 @@ public class LabelPropagationStats {
         private boolean didConverge = false;
         private String weightProperty;
         private String partitionProperty;
+        private String writeProperty;
 
         public Builder iterations(final long iterations) {
             this.iterations = iterations;
@@ -124,6 +127,11 @@ public class LabelPropagationStats {
             this.partitionProperty = partitionProperty;
             return this;
         }
+        public Builder writeProperty(final String writeProperty) {
+            this.writeProperty = writeProperty;
+            return this;
+        }
+
 
         @Override
         protected LabelPropagationStats build(long loadMillis, long computeMillis, long writeMillis, long postProcessingMillis, long nodeCount, long communityCount, LongLongMap communitySizeMap, Histogram communityHistogram, boolean write) {
@@ -148,7 +156,8 @@ public class LabelPropagationStats {
                     write,
                     didConverge,
                     weightProperty,
-                    partitionProperty
+                    partitionProperty,
+                    writeProperty
             );
         }
 

--- a/algo/src/main/java/org/neo4j/graphalgo/results/SCCResult.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/results/SCCResult.java
@@ -28,7 +28,7 @@ public class SCCResult {
 
     public static SCCResult EMPTY = new SCCResult(
             0, 0, 0, 0,0, 0, -1,-1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0,
-            false, null);
+            false, null, null);
 
     public final long loadMillis;
     public final long computeMillis;
@@ -51,10 +51,11 @@ public class SCCResult {
     public final long p100;
     public final boolean write;
     public final String partitionProperty;
+    public final String writeProperty;
 
     public SCCResult(long loadMillis, long computeMillis, long postProcessingMillis, long writeMillis, long nodes, long communityCount,
                      long p100, long p99, long p95, long p90, long p75, long p50, long p25, long p10, long p5, long p1,
-                     long minSetSize, long maxSetSize, boolean write, String partitionProperty) {
+                     long minSetSize, long maxSetSize, boolean write, String partitionProperty, String writeProperty) {
         this.loadMillis = loadMillis;
         this.computeMillis = computeMillis;
         this.postProcessingMillis = postProcessingMillis;
@@ -75,6 +76,7 @@ public class SCCResult {
         this.maxSetSize = maxSetSize;
         this.write = write;
         this.partitionProperty = partitionProperty;
+        this.writeProperty = writeProperty;
     }
 
     public static Builder builder() {
@@ -83,6 +85,7 @@ public class SCCResult {
 
     public static final class Builder extends AbstractCommunityResultBuilder<SCCResult> {
         private String partitionProperty;
+        private String writeProperty;
 
         @Override
         protected SCCResult build(long loadMillis, long computeMillis, long writeMillis, long postProcessingMillis, long nodeCount, long communityCount, LongLongMap communitySizeMap, Histogram communityHistogram, boolean write) {
@@ -106,12 +109,17 @@ public class SCCResult {
                     communityHistogram.getMinNonZeroValue(),
                     communityHistogram.getMaxValue(),
                     write,
-                    partitionProperty
+                    partitionProperty, writeProperty
             );
         }
 
         public Builder withPartitionProperty(String partitionProperty) {
             this.partitionProperty = partitionProperty;
+            return this;
+        }
+
+        public Builder withWriteProperty(String writeProperty) {
+            this.writeProperty = writeProperty;
             return this;
         }
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
@@ -387,6 +387,17 @@ public class ProcedureConfiguration {
         return (V) value;
     }
 
+    public <V> V get(String newKey, String oldKey, V defaultValue) {
+        Object value = config.get(newKey);
+        if (null == value) {
+            value = config.get(oldKey);
+            if(null == value) {
+                return defaultValue;
+            }
+        }
+        return (V) value;
+    }
+
     public static ProcedureConfiguration create(Map<String, Object> config) {
         return new ProcedureConfiguration(config);
     }
@@ -415,4 +426,6 @@ public class ProcedureConfiguration {
         String strategy = get("duplicateRelationships", null);
         return strategy != null ? DuplicateRelationshipsStrategy.valueOf(strategy.toUpperCase()) : DuplicateRelationshipsStrategy.NONE;
     }
+
+
 }

--- a/doc/asciidoc/connected-components.adoc
+++ b/doc/asciidoc/connected-components.adoc
@@ -209,7 +209,7 @@ include::scripts/connected-components.cypher[tag=cypher-loading]
 [source, cypher]
 ----
 CALL algo.unionFind(label:String, relationship:String, {threshold:0.42,
-    defaultValue:1.0, write: true, partitionProperty:'partition', weightProperty:'weight', graph:'heavy', concurrency:4})
+    defaultValue:1.0, write: true, writeProperty:'partition', weightProperty:'weight', graph:'heavy', concurrency:4})
 YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 ----
 
@@ -221,7 +221,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 | relationship      | string  | null           | yes      | The relationship-type to load from the graph. If null, load all relationships
 | weightProperty    | string  | null           | yes      | The property name that contains weight. If null, treats the graph as unweighted. Must be numeric.
 | write             | boolean | true           | yes      | Specifies if the result should be written back as a node property
-| partitionProperty | string  | 'partition'    | yes      | The property name written back the ID of the partition particular node belongs to
+| writeProperty | string  | 'partition'    | yes      | The property name written back the ID of the partition particular node belongs to
 | threshold         | float   | null           | yes      | The value of the weight above which the relationship is not thrown away
 | defaultValue      | float   | null           | yes      | The default value of the weight in case it is missing or invalid
 | concurrency       | int     | available CPUs | yes      | The number of concurrent threads
@@ -252,7 +252,7 @@ YIELD nodes, setCount, loadMillis, computeMillis, writeMillis
 | p100                  | double  | The 100 percentile of community size.
 
 | write | boolean | Specifies if the result was written back as a node property
-| partitionProperty | string | The property name written back to
+| writeProperty | string | The property name written back to
 |===
 
 

--- a/doc/asciidoc/label-propagation.adoc
+++ b/doc/asciidoc/label-propagation.adoc
@@ -160,8 +160,8 @@ include::scripts/label-propagation.cypher[tag=cypher-loading]
 [source, cypher]
 ----
 CALL algo.labelPropagation(label:String, relationship:String, direction:String, {iterations:1,
-    weightProperty:'weight', partitionProperty:'partition', write:true, concurrency:4})
-YIELD nodes, iterations, didConverge, loadMillis, computeMillis, writeMillis, write, weightProperty, partitionProperty
+    weightProperty:'weight', writeProperty:'partition', write:true, concurrency:4})
+YIELD nodes, iterations, didConverge, loadMillis, computeMillis, writeMillis, write, weightProperty, writeProperty
 ----
 
 .Parameters
@@ -174,7 +174,8 @@ YIELD nodes, iterations, didConverge, loadMillis, computeMillis, writeMillis, wr
 | concurrency       | int     | available CPUs | yes      | The number of concurrent threads
 | iterations        | int     | 1              | yes      | The maximum number of iterations to run
 | weightProperty    | string  | 'weight'       | yes      | The property name of node and/or relationship that contain weight. Must be numeric.
-| partitionProperty | string  | 'partition'    | yes      | The property name written back to the partition of the graph in which the node reside. Can be used to define initial set of labels (must be a number)
+| partitionProperty | string  | 'partition'    | yes      | Used to define initial set of labels (must be a number)
+| writeProperty | string  | 'partition'    | yes      | The property name written back to the partition of the graph in which the node resides.
 | write             | boolean | true           | yes      | Specifies if the result should be written back as a node property
 | graph             | string  | 'heavy'        | yes      | Use 'heavy' when describing the subset of the graph with label and relationship-type parameter. Use 'cypher' for describing the subset with cypher node-statement and relationship-statement
 |===
@@ -205,7 +206,7 @@ YIELD nodes, iterations, didConverge, loadMillis, computeMillis, writeMillis, wr
 | p100                  | double  | The 100 percentile of community size.
 
 | write | boolean | Specifies if the result was written back as a node property
-| partitionProperty | string | The property name written back to
+| writeProperty | string | The property name written back to
 | weightProperty | string | The property name that contains weight
 
 |===
@@ -214,7 +215,7 @@ YIELD nodes, iterations, didConverge, loadMillis, computeMillis, writeMillis, wr
 [source,cypher]
 ----
 CALL algo.labelPropagation.stream(label:String, relationship:String, {iterations:1,
-    weightProperty:'weight', partitionProperty:'partition', concurrency:4, direction:'OUTGOING'})
+    weightProperty:'weight', writeProperty:'partition', concurrency:4, direction:'OUTGOING'})
 YIELD nodeId, label
 ----
 
@@ -228,7 +229,8 @@ YIELD nodeId, label
 | concurrency       | int    | available CPUs | yes      | The number of concurrent threads
 | iterations        | int    | 1              | yes      | The maximum number of iterations to run
 | weightProperty    | string | 'weight'       | yes      | The property name of node and/or relationship that contain weight. Must be numeric.
-| partitionProperty | string | 'partition'    | yes      | The property name written back to the partition of the graph in which the node reside. Can be used to define initial set of labels (must be a number)
+| partitionProperty | string  | 'partition'    | yes      | Used to define initial set of labels (must be a number)
+| writeProperty | string  | 'partition'    | yes      | The property name written back to the partition of the graph in which the node resides.
 | graph             | string | 'heavy'        | yes      | Use 'heavy' when describing the subset of the graph with label and relationship-type parameter. Use 'cypher' for describing the subset with cypher node-statement and relationship-statement
 |===
 

--- a/doc/asciidoc/strongly-connected-components.adoc
+++ b/doc/asciidoc/strongly-connected-components.adoc
@@ -129,7 +129,7 @@ include::scripts/strongly-connected-components.cypher[tag=cypher-loading]
 [source, cypher]
 ----
 CALL algo.scc(label:String, relationship:String,
-    {write:true,partitionProperty:'partition',concurrency:4, graph:'heavy'})
+    {write:true,writeProperty:'partition',concurrency:4, graph:'heavy'})
 YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 ----
 
@@ -140,7 +140,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 | label             | string  | null           | yes      | The label to load from the graph. If null, load all nodes
 | relationship      | string  | null           | yes      | The relationship-type to load from the graph. If null, load all relationships
 | write             | boolean | true           | yes      | Specifies if the result should be written back as a node property
-| partitionProperty | string  | 'partition'    | yes      | The property name written back to
+| writeProperty | string  | 'partition'    | yes      | The property name written back to
 | concurrency       | int     | available CPUs | yes      | The number of concurrent threads
 | graph             | string  | 'heavy'        | yes      | Use 'heavy' when describing the subset of the graph with label and relationship-type parameter. Use 'cypher' for describing the subset with cypher node-statement and relationship-statement
 |===
@@ -169,7 +169,7 @@ YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize
 | p100                  | double  | The 100 percentile of community size.
 
 | write | boolean | Specifies if the result was written back as a node property
-| partitionProperty | string | The property name written back to
+| writeProperty | string | The property name written back to
 
 |===
 

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -103,7 +103,20 @@ public class LabelPropagationProcIntegrationTest {
 
     @Test
     public void explicitWriteProperty() {
-        String query = "CALL algo.labelPropagation(null, null, 'BOTH', {writeProperty: 'lpa'})";
+        String query = "CALL algo.labelPropagation(null, null, null, {writeProperty: 'lpa'})";
+
+        runQuery(query, row -> {
+            assertEquals(1, row.getNumber("iterations").intValue());
+            assertEquals("weight", row.getString("weightProperty"));
+            assertEquals("partition", row.getString("partitionProperty"));
+            assertEquals("lpa", row.getString("writeProperty"));
+            assertTrue(row.getBoolean("write"));
+        });
+    }
+
+    @Test
+    public void explicitWritePropertyWithConfigAs3rdParameter() {
+        String query = "CALL algo.labelPropagation(null, null, {writeProperty: 'lpa'})";
 
         runQuery(query, row -> {
             assertEquals(1, row.getNumber("iterations").intValue());

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -96,6 +96,20 @@ public class LabelPropagationProcIntegrationTest {
             assertEquals(1, row.getNumber("iterations").intValue());
             assertEquals("weight", row.getString("weightProperty"));
             assertEquals("partition", row.getString("partitionProperty"));
+            assertEquals("partition", row.getString("writeProperty"));
+            assertTrue(row.getBoolean("write"));
+        });
+    }
+
+    @Test
+    public void explicitWriteProperty() {
+        String query = "CALL algo.labelPropagation(null, null, 'BOTH', {writeProperty: 'lpa'})";
+
+        runQuery(query, row -> {
+            assertEquals(1, row.getNumber("iterations").intValue());
+            assertEquals("weight", row.getString("weightProperty"));
+            assertEquals("partition", row.getString("partitionProperty"));
+            assertEquals("lpa", row.getString("writeProperty"));
             assertTrue(row.getBoolean("write"));
         });
     }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/StronglyConnectedComponentsProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/StronglyConnectedComponentsProcIntegrationTest.java
@@ -96,20 +96,31 @@ public class StronglyConnectedComponentsProcIntegrationTest {
 
     @Test
     public void testScc() throws Exception {
-
-        db.execute("CALL algo.scc('Node', 'TYPE', {write:true, graph:'"+graphImpl+"'}) YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize")
+        db.execute("CALL algo.scc('Node', 'TYPE', {write:true, graph:'"+graphImpl+"'}) YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize, partitionProperty, writeProperty")
                 .accept(row -> {
-
-                    System.out.println(row.getNumber("loadMillis").longValue());
-                    System.out.println(row.getNumber("computeMillis").longValue());
-                    System.out.println(row.getNumber("writeMillis").longValue());
-                    System.out.println(row.getNumber("setCount").longValue());
-
                     assertNotEquals(-1L, row.getNumber("computeMillis").longValue());
                     assertNotEquals(-1L, row.getNumber("writeMillis").longValue());
                     assertEquals(2, row.getNumber("setCount").longValue());
                     assertEquals(2, row.getNumber("minSetSize").longValue());
                     assertEquals(3, row.getNumber("maxSetSize").longValue());
+                    assertEquals("partition", row.getString("partitionProperty"));
+                    assertEquals("partition", row.getString("writeProperty"));
+
+                    return true;
+                });
+    }
+
+    @Test
+    public void explicitWriteProperty() throws Exception {
+        db.execute("CALL algo.scc('Node', 'TYPE', {write:true, graph:'"+graphImpl+"', writeProperty: 'scc'}) YIELD loadMillis, computeMillis, writeMillis, setCount, maxSetSize, minSetSize, partitionProperty, writeProperty")
+                .accept(row -> {
+                    assertNotEquals(-1L, row.getNumber("computeMillis").longValue());
+                    assertNotEquals(-1L, row.getNumber("writeMillis").longValue());
+                    assertEquals(2, row.getNumber("setCount").longValue());
+                    assertEquals(2, row.getNumber("minSetSize").longValue());
+                    assertEquals(3, row.getNumber("maxSetSize").longValue());
+                    assertEquals("scc", row.getString("partitionProperty"));
+                    assertEquals("scc", row.getString("writeProperty"));
 
                     return true;
                 });

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/UnionFindProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/UnionFindProcIntegrationTest.java
@@ -130,15 +130,32 @@ public class UnionFindProcIntegrationTest {
 
     @Test
     public void testUnionFindWriteBack() throws Exception {
-        db.execute("CALL algo.unionFind('', 'TYPE', {write:true,graph:'"+graphImpl+"'}) YIELD setCount, communityCount, writeMillis, nodes")
+        db.execute("CALL algo.unionFind('', 'TYPE', {write:true,graph:'"+graphImpl+"'}) YIELD setCount, communityCount, writeMillis, nodes, partitionProperty, writeProperty")
                 .accept((Result.ResultVisitor<Exception>) row -> {
                     assertNotEquals(-1L, row.getNumber("writeMillis"));
                     assertNotEquals(-1L, row.getNumber("nodes"));
                     assertEquals(3L, row.getNumber("communityCount"));
                     assertEquals(3L, row.getNumber("setCount"));
+                    assertEquals("partition", row.getString("partitionProperty"));
+                    assertEquals("partition", row.getString("writeProperty"));
                     return false;
                 });
     }
+
+    @Test
+    public void testUnionFindWriteBackExplicitWriteProperty() throws Exception {
+        db.execute("CALL algo.unionFind('', 'TYPE', {write:true,graph:'"+graphImpl+"', writeProperty:'unionFind'}) YIELD setCount, communityCount, writeMillis, nodes, partitionProperty, writeProperty")
+                .accept((Result.ResultVisitor<Exception>) row -> {
+                    assertNotEquals(-1L, row.getNumber("writeMillis"));
+                    assertNotEquals(-1L, row.getNumber("nodes"));
+                    assertEquals(3L, row.getNumber("communityCount"));
+                    assertEquals(3L, row.getNumber("setCount"));
+                    assertEquals("unionFind", row.getString("partitionProperty"));
+                    assertEquals("unionFind", row.getString("writeProperty"));
+                    return false;
+                });
+    }
+
 
     @Test
     public void testUnionFindStream() throws Exception {

--- a/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
@@ -1,0 +1,54 @@
+package org.neo4j.graphalgo.core;
+
+import org.junit.Test;
+import org.neo4j.helpers.collection.MapUtil;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ProcedureConfigurationTest {
+
+    @Test
+    public void useDefault() {
+        Map<String, Object> map = Collections.emptyMap();
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        String value = procedureConfiguration.get("partitionProperty", "defaultValue");
+        assertEquals(value, "defaultValue");
+    }
+
+    @Test
+    public void returnValueIfPresent() {
+        Map<String, Object> map = MapUtil.map("partitionProperty", "partition");
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        String value = procedureConfiguration.get("partitionProperty", "defaultValue");
+        assertEquals(value, "partition");
+    }
+
+    @Test
+    public void newKeyIfPresent() {
+        Map<String, Object> map = MapUtil.map("partitionProperty", "old", "writeProperty", "new");
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
+        assertEquals(value, "new");
+    }
+
+    @Test
+    public void oldKeyIfNewKeyNotPresent() {
+        Map<String, Object> map = MapUtil.map("partitionProperty", "old");
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
+        assertEquals(value, "old");
+    }
+
+    @Test
+    public void defaultIfNoKeysPresent() {
+        Map<String, Object> map = Collections.emptyMap();
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
+        assertEquals(value, "defaultValue");
+    }
+
+
+}

--- a/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
@@ -15,7 +15,7 @@ public class ProcedureConfigurationTest {
         Map<String, Object> map = Collections.emptyMap();
         ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
         String value = procedureConfiguration.get("partitionProperty", "defaultValue");
-        assertEquals(value, "defaultValue");
+        assertEquals("defaultValue", value);
     }
 
     @Test
@@ -23,7 +23,7 @@ public class ProcedureConfigurationTest {
         Map<String, Object> map = MapUtil.map("partitionProperty", "partition");
         ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
         String value = procedureConfiguration.get("partitionProperty", "defaultValue");
-        assertEquals(value, "partition");
+        assertEquals("partition", value);
     }
 
     @Test
@@ -31,7 +31,7 @@ public class ProcedureConfigurationTest {
         Map<String, Object> map = MapUtil.map("partitionProperty", "old", "writeProperty", "new");
         ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
         String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
-        assertEquals(value, "new");
+        assertEquals("new", value);
     }
 
     @Test
@@ -39,7 +39,7 @@ public class ProcedureConfigurationTest {
         Map<String, Object> map = MapUtil.map("partitionProperty", "old");
         ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
         String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
-        assertEquals(value, "old");
+        assertEquals("old", value);
     }
 
     @Test
@@ -47,6 +47,27 @@ public class ProcedureConfigurationTest {
         Map<String, Object> map = Collections.emptyMap();
         ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
         String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
-        assertEquals(value, "defaultValue");
+        assertEquals("defaultValue", value);
+    }
+
+    @Test
+    public void defaultIfKeyMissing() {
+        Map<String, Object> map = Collections.emptyMap();
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        assertEquals("defaultValue", procedureConfiguration.getString("writeProperty", "defaultValue"));
+    }
+
+    @Test
+    public void defaultIfKeyPresentButNoValue() {
+        Map<String, Object> map = MapUtil.map("writeProperty", "");
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        assertEquals("defaultValue", procedureConfiguration.getString("writeProperty", "defaultValue"));
+    }
+
+    @Test
+    public void valueIfKeyPresent() {
+        Map<String, Object> map = MapUtil.map("writeProperty", "scc");
+        ProcedureConfiguration procedureConfiguration = new ProcedureConfiguration(map);
+        assertEquals("scc", procedureConfiguration.getString("writeProperty", "defaultValue"));
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/ProcedureConfigurationTest.java
@@ -49,6 +49,4 @@ public class ProcedureConfigurationTest {
         String value = procedureConfiguration.get("writeProperty", "partitionProperty", "defaultValue");
         assertEquals(value, "defaultValue");
     }
-
-
 }


### PR DESCRIPTION
This PR refactors the community detection algorithms, specifically:

* All use `writeProperty` to store results. It will fall back to `partitionProperty` (the old key) if it's not specified
* Label Propagation write version overloads on the 3rd parameter so that it has the same signature as other algos. Will still respect the old signature if 4 arguments are provided