### PR TITLE
Support {graph:'huge'} for label propagation

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/results/AbstractCommunityResultBuilder.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/results/AbstractCommunityResultBuilder.java
@@ -24,8 +24,8 @@ import org.HdrHistogram.Histogram;
 import org.neo4j.graphalgo.core.utils.ProgressTimer;
 
 import java.util.function.IntFunction;
-import java.util.function.LongFunction;
 import java.util.function.LongToIntFunction;
+import java.util.function.LongUnaryOperator;
 
 /**
  * @author mknblch
@@ -174,13 +174,13 @@ public abstract class AbstractCommunityResultBuilder<T> {
     /**
      * build result
      */
-    public T build(long nodeCount, LongFunction<Long> fun) {
+    public T build(long nodeCount, LongUnaryOperator fun) {
 
         final LongLongMap communitySizeMap = new LongLongScatterMap();
         final ProgressTimer timer = ProgressTimer.start();
-        for (int nodeId = 0; nodeId < nodeCount; nodeId++) {
-            final long communityId = fun.apply(nodeId);
-            communitySizeMap.addTo(communityId, 1);
+        for (long nodeId = 0L; nodeId < nodeCount; nodeId++) {
+            final long communityId = fun.applyAsLong(nodeId);
+            communitySizeMap.addTo(communityId, 1L);
         }
 
         Histogram histogram = CommunityHistogram.buildFrom(communitySizeMap);

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/LabelPropagationBenchmarkLdbc.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/LabelPropagationBenchmarkLdbc.java
@@ -117,7 +117,8 @@ public class LabelPropagationBenchmarkLdbc {
 
     @Benchmark
     public Object _03_direct() {
-        return new org.neo4j.graphalgo.impl.LabelPropagation(graph, batchSize, Pools.DEFAULT_CONCURRENCY, Pools.DEFAULT)
+        return new org.neo4j.graphalgo.impl
+                .LabelPropagation(graph, graph, batchSize, Pools.DEFAULT_CONCURRENCY, Pools.DEFAULT)
                 .compute(Direction.OUTGOING, iterations);
     }
 

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/PageRankBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/PageRankBenchmark.java
@@ -20,7 +20,6 @@ package org.neo4j.graphalgo.bench;
 
 import org.neo4j.graphalgo.api.Graph;
 import org.neo4j.graphalgo.core.GraphLoader;
-import org.neo4j.graphalgo.impl.pagerank.PageRankResult;
 import org.neo4j.graphalgo.impl.pagerank.PageRankAlgorithm;
 import org.neo4j.graphalgo.impl.results.CentralityResult;
 import org.neo4j.graphdb.Direction;

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/ScanningMain.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/ScanningMain.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.neo4j.function.Predicates;
 import org.neo4j.graphalgo.core.huge.loader.AbstractStorePageCacheScanner;
 import org.neo4j.graphalgo.core.utils.Pools;
+import org.neo4j.graphalgo.helper.ldbc.LdbcDownloader;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;

--- a/benchmark/src/main/java/org/neo4j/graphalgo/impl/msbfs/MSBFSSource.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/impl/msbfs/MSBFSSource.java
@@ -18,7 +18,13 @@
  */
 package org.neo4j.graphalgo.impl.msbfs;
 
-import org.neo4j.graphalgo.api.*;
+import org.neo4j.graphalgo.api.HugeIdMapping;
+import org.neo4j.graphalgo.api.HugeRelationshipConsumer;
+import org.neo4j.graphalgo.api.HugeRelationshipIterator;
+import org.neo4j.graphalgo.api.HugeWeightedRelationshipConsumer;
+import org.neo4j.graphalgo.api.IdMapping;
+import org.neo4j.graphalgo.api.RelationshipConsumer;
+import org.neo4j.graphalgo.api.RelationshipIterator;
 import org.neo4j.graphalgo.core.huge.HugeDirectIdMapping;
 import org.neo4j.graphalgo.core.neo4jview.DirectIdMapping;
 import org.neo4j.graphdb.Direction;
@@ -110,15 +116,12 @@ public enum MSBFSSource {
             }
         }
 
+        @Override
         public void forEachRelationship(
                 long nodeId,
                 Direction direction,
                 HugeWeightedRelationshipConsumer consumer) {
-            for (long i = 0; i < nodeCount; i++) {
-                if (i != nodeId) {
-                    consumer.accept(nodeId, i, 1.0);
-                }
-            }
+            forEachRelationship(nodeId, direction, (s, t) -> consumer.accept(s, t, Double.NaN));
         }
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeGraph.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeGraph.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  *
  * @author mknblch
  */
-public interface HugeGraph extends HugeIdMapping, HugeDegrees, HugeNodeIterator, HugeBatchNodeIterable, HugeRelationshipIterator, HugeRelationshipWeights, HugeRelationshipPredicate, HugeRelationshipAccess, Graph {
+public interface HugeGraph extends HugeIdMapping, HugeDegrees, HugeNodeIterator, HugeBatchNodeIterable, HugeRelationshipIterator, HugeRelationshipWeights, HugeRelationshipPredicate, HugeRelationshipAccess, HugeNodeProperties, Graph {
 
     String TYPE = "huge";
 
@@ -88,7 +88,6 @@ public interface HugeGraph extends HugeIdMapping, HugeDegrees, HugeNodeIterator,
             int targetNodeId) {
         return weightOf((long) sourceNodeId, (long) targetNodeId);
     }
-
 
     final class LongToIntIterator implements PrimitiveIntIterator {
         private final PrimitiveLongIterator iter;

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeNodeProperties.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeNodeProperties.java
@@ -18,32 +18,21 @@
  */
 package org.neo4j.graphalgo.api;
 
-import org.neo4j.graphalgo.core.utils.RawValues;
-
 /**
- * @author mknobloch
+ * Getter interface for node properties for huge graphs.
  */
-public interface WeightMapping {
+public interface HugeNodeProperties extends NodeProperties {
 
     /**
-     * returns the weight for ID if set or the load-time specified default weight otherwise
+     * return the property mapping for a type
+     *
+     * @param type       the node property type
+     * @return the mapping associated with that type
      */
-    double get(long id);
+    HugeWeightMapping hugeNodeProperties(String type);
 
-    /**
-     * returns the weight for ID if set or the given default weight otherwise
-     */
-    double get(long id, double defaultValue);
-
-    default double get(int source, int target) {
-        return get(RawValues.combineIntInt(source, target));
-    }
-
-    default double get(int id) {
-        return get(RawValues.combineIntInt(id, -1));
-    }
-
-    default double get(int id, double defaultValue) {
-        return get(RawValues.combineIntInt(id, -1), defaultValue);
+    @Override
+    default WeightMapping nodeProperties(String type) {
+        return hugeNodeProperties(type);
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/api/HugeWeightMapping.java
+++ b/core/src/main/java/org/neo4j/graphalgo/api/HugeWeightMapping.java
@@ -18,12 +18,37 @@
  */
 package org.neo4j.graphalgo.api;
 
-public interface HugeWeightMapping {
+import static org.neo4j.graphalgo.core.utils.RawValues.getHead;
+import static org.neo4j.graphalgo.core.utils.RawValues.getTail;
+
+public interface HugeWeightMapping extends WeightMapping {
+
+    /**
+     * returns the weight for the relationship defined by their start and end nodes.
+     */
+    double weight(long source, long target);
 
     /**
      * returns the weight for the relationship defined by their start and end nodes
+     * or the given default weight if no weight has been defined.
+     * The default weight has precedence over the default weight defined by the loader.
      */
-    double weight(long source, long target);
+    double weight(long source, long target, double defaultValue);
+
+    /**
+     * returns the weight for a node or the loaded default weight if no weight has been defined.
+     */
+    default double nodeWeight(long nodeId) {
+        return weight(nodeId, -1L);
+    }
+
+    /**
+     * returns the weight for a node or the given default weight if no weight has been defined.
+     * The default weight has precedence over the default weight defined by the loader.
+     */
+    default double nodeWeight(long nodeId, double defaultValue) {
+        return weight(nodeId, -1L, defaultValue);
+    }
 
     /**
      * release internal data structures and return an estimate how many
@@ -31,4 +56,34 @@ public interface HugeWeightMapping {
      * The mapping is not usable afterwards.
      */
     long release();
+
+    // WeightMapping
+    @Override
+    default double get(long id) {
+        return weight((long) getHead(id), (long) getTail(id));
+    }
+
+    // WeightMapping
+    @Override
+    default double get(final long id, final double defaultValue) {
+        return weight((long) getHead(id), (long) getTail(id), defaultValue);
+    }
+
+    // WeightMapping
+    @Override
+    default double get(int source, int target) {
+        return weight((long) source, (long) target);
+    }
+
+    // WeightMapping
+    @Override
+    default double get(int id) {
+        return nodeWeight((long) id);
+    }
+
+    // WeightMapping
+    @Override
+    default double get(int id, double defaultValue) {
+        return nodeWeight((long) id, defaultValue);
+    }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/GraphDimensions.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/GraphDimensions.java
@@ -104,6 +104,13 @@ public final class GraphDimensions extends StatementFunction<GraphDimensions> {
         return -1;
     }
 
+    public int nodePropertyKeyId(int mappingIndex) {
+        if (mappingIndex < 0 || mappingIndex >= nodePropIds.length) {
+            return TokenRead.NO_TOKEN;
+        }
+        return nodePropIds[mappingIndex];
+    }
+
     public double nodePropertyDefaultValue(String type) {
         PropertyMapping[] mappings = setup.nodePropertyMappings;
 

--- a/core/src/main/java/org/neo4j/graphalgo/core/NullWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/NullWeightMap.java
@@ -58,9 +58,4 @@ public class NullWeightMap implements WeightMapping {
     public double get(final int id, final double defaultValue) {
         return defaultValue;
     }
-
-    @Override
-    public int size() {
-        return 0;
-    }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/ProcedureConfiguration.java
@@ -290,9 +290,7 @@ public class ProcedureConfiguration {
     }
 
     /**
-     * return the Graph-Implementation Factory class
-     *
-     * @return
+     * @return the Graph-Implementation Factory class
      */
     public Class<? extends GraphFactory> getGraphImpl(String defaultGraphImpl) {
         final String graphImpl = getGraphName(defaultGraphImpl);

--- a/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/WeightMap.java
@@ -88,7 +88,6 @@ public final class WeightMap implements WeightMapping {
         return propertyId;
     }
 
-    @Override
     public int size() {
         return weights.size();
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/heavyweight/RelationshipImporter.java
@@ -37,10 +37,8 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 
 final class RelationshipImporter extends StatementAction {

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeAdjacencyBuilder.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeAdjacencyBuilder.java
@@ -27,6 +27,7 @@ import org.neo4j.graphalgo.core.huge.HugeAdjacencyOffsets;
 import org.neo4j.graphalgo.core.huge.HugeGraphImpl;
 import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
 
+import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.neo4j.graphalgo.core.huge.loader.AdjacencyCompression.writeDegree;
@@ -117,6 +118,7 @@ class HugeAdjacencyBuilder {
             final AllocationTracker tracker,
             final HugeIdMap idMapping,
             final HugeWeightMapping weights,
+            final Map<String, HugeWeightMapping> nodeProperties,
             final HugeAdjacencyBuilder inAdjacency,
             final HugeAdjacencyBuilder outAdjacency) {
 
@@ -134,7 +136,7 @@ class HugeAdjacencyBuilder {
         }
 
         return new HugeGraphImpl(
-                tracker, idMapping, weights,
+                tracker, idMapping, weights, nodeProperties,
                 inAdjacencyList, outAdjacencyList, inOffsets, outOffsets
         );
     }

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeNodePropertiesBuilder.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeNodePropertiesBuilder.java
@@ -1,0 +1,47 @@
+package org.neo4j.graphalgo.core.huge.loader;
+
+import org.neo4j.graphalgo.api.HugeWeightMapping;
+import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
+import org.neo4j.kernel.api.StatementConstants;
+
+final class HugeNodePropertiesBuilder {
+
+    private final double defaultValue;
+    private final int propertyId;
+    private final PagedPropertyMap properties;
+
+    public static HugeNodePropertiesBuilder of(
+            long numberOfNodes,
+            AllocationTracker tracker,
+            double defaultValue,
+            int propertyId) {
+        assert propertyId != StatementConstants.NO_SUCH_PROPERTY_KEY;
+        PagedPropertyMap properties = PagedPropertyMap.of(numberOfNodes, tracker);
+        return new HugeNodePropertiesBuilder(defaultValue, propertyId, properties);
+    }
+
+    private HugeNodePropertiesBuilder(
+            final double defaultValue,
+            final int propertyId,
+            final PagedPropertyMap properties) {
+        this.defaultValue = defaultValue;
+        this.propertyId = propertyId;
+        this.properties = properties;
+    }
+
+    double defaultValue() {
+        return defaultValue;
+    }
+
+    int propertyId() {
+        return propertyId;
+    }
+
+    void set(long index, double value) {
+        properties.put(index, value);
+    }
+
+    HugeWeightMapping build() {
+        return new HugeNodePropertyMap(properties, defaultValue, propertyId);
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeNodePropertyMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeNodePropertyMap.java
@@ -20,67 +20,49 @@ package org.neo4j.graphalgo.core.huge.loader;
 
 import org.neo4j.graphalgo.api.HugeWeightMapping;
 
-/**
- * WeightMapping implementation which always returns
- * a given default weight upon invocation
- *
- * @author mknblch
- */
-class HugeNullWeightMap implements HugeWeightMapping {
+final class HugeNodePropertyMap implements HugeWeightMapping {
 
+    private PagedPropertyMap properties;
     private final double defaultValue;
+    private final int propertyId;
 
-    HugeNullWeightMap(double defaultValue) {
+    HugeNodePropertyMap(PagedPropertyMap properties, double defaultValue, int propertyId) {
+        this.properties = properties;
         this.defaultValue = defaultValue;
+        this.propertyId = propertyId;
     }
 
     @Override
     public double weight(final long source, final long target) {
-        return defaultValue;
+        assert target == -1L;
+        return properties.getOrDefault(source, defaultValue);
     }
 
     @Override
     public double weight(final long source, final long target, final double defaultValue) {
+        assert target == -1L;
+        return properties.getOrDefault(source, defaultValue);
+    }
+
+    public double defaultValue() {
         return defaultValue;
     }
 
-    @Override
-    public double nodeWeight(final long nodeId) {
-        return defaultValue;
-    }
-
-    @Override
-    public double nodeWeight(final long nodeId, final double defaultValue) {
-        return defaultValue;
-    }
-
-    @Override
-    public double get(final long id) {
-        return defaultValue;
-    }
-
-    @Override
-    public double get(final long id, final double defaultValue) {
-        return defaultValue;
-    }
-
-    @Override
-    public double get(final int source, final int target) {
-        return defaultValue;
-    }
-
-    @Override
-    public double get(final int id) {
-        return defaultValue;
-    }
-
-    @Override
-    public double get(final int id, final double defaultValue) {
-        return defaultValue;
+    public void put(long nodeId, double value) {
+        properties.put(nodeId, value);
     }
 
     @Override
     public long release() {
+        if (properties != null) {
+            long freed = properties.release();
+            properties = null;
+            return freed;
+        }
         return 0L;
+    }
+
+    public int propertyId() {
+        return propertyId;
     }
 }

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeWeightMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/HugeWeightMap.java
@@ -56,9 +56,14 @@ abstract class HugeWeightMap {
 
         @Override
         public double weight(final long source, final long target) {
-            int localIndex = (int) source;
-            return get(localIndex, target, defaultValue);
+            return weight(source, target, defaultValue);
         }
+
+         @Override
+         public double weight(final long source, final long target, final double defaultValue) {
+             int localIndex = (int) source;
+             return get(localIndex, target, defaultValue);
+         }
 
         double get(int localIndex, long target, double defaultValue) {
             TrackingLongDoubleHashMap map = data[localIndex];
@@ -119,6 +124,11 @@ abstract class HugeWeightMap {
 
         @Override
         public double weight(final long source, final long target) {
+            return weight(source, target, defaultValue);
+        }
+
+        @Override
+        public double weight(final long source, final long target, final double defaultValue) {
             int pageIndex = (int) (source >>> pageShift);
             Page page = pages[pageIndex];
             if (page != null) {

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/IdsAndProperties.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/IdsAndProperties.java
@@ -1,0 +1,18 @@
+package org.neo4j.graphalgo.core.huge.loader;
+
+import org.neo4j.graphalgo.api.HugeWeightMapping;
+
+import java.util.Map;
+
+final class IdsAndProperties {
+
+    final HugeIdMap hugeIdMap;
+    final Map<String, HugeWeightMapping> properties;
+
+    IdsAndProperties(
+            final HugeIdMap hugeIdMap,
+            final Map<String, HugeWeightMapping> properties) {
+        this.hugeIdMap = hugeIdMap;
+        this.properties = properties;
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/PagedPropertyMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/huge/loader/PagedPropertyMap.java
@@ -1,0 +1,100 @@
+package org.neo4j.graphalgo.core.huge.loader;
+
+import com.carrotsearch.hppc.IntDoubleMap;
+import org.neo4j.graphalgo.core.utils.container.TrackingIntDoubleHashMap;
+import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
+import org.neo4j.graphalgo.core.utils.paged.HugeLongArray;
+import org.neo4j.graphalgo.core.utils.paged.PageUtil;
+
+import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.shallowSizeOfInstance;
+import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfObjectArray;
+
+final class PagedPropertyMap {
+
+    private static final int PAGE_SHIFT = 14;
+    private static final int PAGE_SIZE = 1 << PAGE_SHIFT;
+    private static final long PAGE_MASK = (long) (PAGE_SIZE - 1);
+
+    static PagedPropertyMap of(long size, AllocationTracker tracker) {
+        int numPages = PageUtil.numPagesFor(size, PAGE_SHIFT, PAGE_MASK);
+        TrackingIntDoubleHashMap[] pages = new TrackingIntDoubleHashMap[numPages];
+
+        tracker.add(shallowSizeOfInstance(HugeLongArray.class));
+        tracker.add(sizeOfObjectArray(numPages));
+
+        return new PagedPropertyMap(size, pages, tracker);
+    }
+
+    private final long size;
+    private final AllocationTracker tracker;
+    private TrackingIntDoubleHashMap[] pages;
+
+    private PagedPropertyMap(
+            long size,
+            TrackingIntDoubleHashMap[] pages,
+            AllocationTracker tracker) {
+        this.size = size;
+        this.pages = pages;
+        this.tracker = tracker;
+    }
+
+    public double getOrDefault(long index, double defaultValue) {
+        assert index < size;
+        int pageIndex = pageIndex(index);
+        int indexInPage = indexInPage(index);
+        IntDoubleMap page = pages[pageIndex];
+        return page == null ? defaultValue : page.getOrDefault(indexInPage, defaultValue);
+    }
+
+    public void put(long index, double value) {
+        assert index < size;
+        int pageIndex = pageIndex(index);
+        int indexInPage = indexInPage(index);
+        TrackingIntDoubleHashMap subMap = subMap(pageIndex);
+        subMap.putSync(indexInPage, value);
+    }
+
+    private TrackingIntDoubleHashMap subMap(int pageIndex) {
+        TrackingIntDoubleHashMap subMap = pages[pageIndex];
+        if (subMap != null) {
+            return subMap;
+        }
+        return forceNewSubMap(pageIndex);
+    }
+
+    private synchronized TrackingIntDoubleHashMap forceNewSubMap(int pageIndex) {
+        TrackingIntDoubleHashMap subMap = pages[pageIndex];
+        if (subMap == null) {
+            subMap = new TrackingIntDoubleHashMap(tracker);
+            pages[pageIndex] = subMap;
+        }
+        return subMap;
+    }
+
+    public long size() {
+        return size;
+    }
+
+    public long release() {
+        if (pages != null) {
+            TrackingIntDoubleHashMap[] pages = this.pages;
+            this.pages = null;
+            long released = sizeOfObjectArray(pages.length);
+            for (TrackingIntDoubleHashMap page : pages) {
+                if (page != null) {
+                    released += page.instanceSize();
+                }
+            }
+            return released;
+        }
+        return 0L;
+    }
+
+    private static int pageIndex(long index) {
+        return (int) (index >>> PAGE_SHIFT);
+    }
+
+    private static int indexInPage(long index) {
+        return (int) (index & PAGE_MASK);
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/container/TrackingIntDoubleHashMap.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/container/TrackingIntDoubleHashMap.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2017 "Neo4j, Inc." <http://neo4j.com>
+ *
+ * This file is part of Neo4j Graph Algorithms <http://github.com/neo4j-contrib/neo4j-graph-algorithms>.
+ *
+ * Neo4j Graph Algorithms is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphalgo.core.utils.container;
+
+import com.carrotsearch.hppc.HashOrderMixing;
+import com.carrotsearch.hppc.IntDoubleHashMap;
+import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
+
+import java.util.concurrent.atomic.LongAdder;
+
+import static com.carrotsearch.hppc.Containers.DEFAULT_EXPECTED_ELEMENTS;
+import static com.carrotsearch.hppc.HashContainers.DEFAULT_LOAD_FACTOR;
+import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfDoubleArray;
+import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfIntArray;
+
+
+public final class TrackingIntDoubleHashMap extends IntDoubleHashMap {
+    private final AllocationTracker tracker;
+    private final LongAdder instanceSize;
+
+    public TrackingIntDoubleHashMap(AllocationTracker tracker) {
+        super(DEFAULT_EXPECTED_ELEMENTS, DEFAULT_LOAD_FACTOR, HashOrderMixing.defaultStrategy());
+        this.tracker = tracker;
+        this.instanceSize = new LongAdder();
+        trackBuffers(keys.length);
+    }
+
+    @Override
+    protected void allocateBuffers(final int arraySize) {
+        // also during super class init where tracker is not yet initialized
+        if (!AllocationTracker.isTracking(tracker)) {
+            super.allocateBuffers(arraySize);
+            return;
+        }
+        int lengthBefore = keys.length;
+        super.allocateBuffers(arraySize);
+        int lengthAfter = keys.length;
+        long addedMemory = bufferUsage(-lengthBefore) + bufferUsage(lengthAfter);
+        tracker.add(addedMemory);
+        instanceSize.add(addedMemory);
+    }
+
+    private void trackBuffers(int length) {
+        tracker.add(sizeOfIntArray(length));
+        tracker.add(sizeOfDoubleArray(length));
+    }
+
+    private long bufferUsage(int length) {
+        return sizeOfIntArray(length) + sizeOfDoubleArray(length);
+    }
+
+    public long instanceSize() {
+        return instanceSize.sum();
+    }
+
+    public synchronized void putSync(int key, double value) {
+        put(key, value);
+    }
+}

--- a/core/src/main/java/org/neo4j/graphalgo/core/utils/paged/HugeLongArrayBuilder.java
+++ b/core/src/main/java/org/neo4j/graphalgo/core/utils/paged/HugeLongArrayBuilder.java
@@ -18,7 +18,11 @@ public final class HugeLongArrayBuilder {
         this.array = array;
         this.numberOfNodes = numberOfNodes;
         this.allocationIndex = new AtomicLong();
-        this.adders = ThreadLocal.withInitial(() -> new BulkAdder(array, array.newCursor()));
+        this.adders = ThreadLocal.withInitial(this::newBulkAdder);
+    }
+
+    private BulkAdder newBulkAdder() {
+        return new BulkAdder(array, array.newCursor());
     }
 
     public BulkAdder allocate(final long nodes) {
@@ -51,7 +55,7 @@ public final class HugeLongArrayBuilder {
         public long[] buffer;
         public int offset;
         public int length;
-
+        public long start;
         private final HugeLongArray array;
         private final HugeLongArray.Cursor cursor;
 
@@ -64,6 +68,7 @@ public final class HugeLongArrayBuilder {
 
         private void reset(long start, long end) {
             array.cursor(this.cursor, start, end);
+            this.start = start;
             buffer = null;
             offset = 0;
             length = 0;

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -25,9 +25,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.graphalgo.LabelPropagationProc;
-import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -62,11 +60,13 @@ public class LabelPropagationProcIntegrationTest {
             "CREATE (b)-[:X]->(:B {id: 10, weight: 1.0, partition: 1}) " +
             "CREATE (b)-[:X]->(:B {id: 11, weight: 8.0, partition: 2})";
 
-    @Parameterized.Parameters(name = "parallel={0}")
+    @Parameterized.Parameters(name = "parallel={0}, graph={1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
-                new Object[]{false},
-                new Object[]{true}
+                new Object[]{false, "heavy"},
+                new Object[]{true, "heavy"},
+                new Object[]{false, "huge"},
+                new Object[]{true, "huge"}
         );
     }
 
@@ -77,9 +77,11 @@ public class LabelPropagationProcIntegrationTest {
     public ExpectedException exceptions = ExpectedException.none();
 
     private final boolean parallel;
+    private final String graphImpl;
 
-    public LabelPropagationProcIntegrationTest(boolean parallel) {
+    public LabelPropagationProcIntegrationTest(boolean parallel, String graphImpl) {
         this.parallel = parallel;
+        this.graphImpl = graphImpl;
     }
 
     @Before
@@ -115,19 +117,6 @@ public class LabelPropagationProcIntegrationTest {
     }
 
     @Test
-    public void explicitWritePropertyWithConfigAs3rdParameter() {
-        String query = "CALL algo.labelPropagation(null, null, {writeProperty: 'lpa'})";
-
-        runQuery(query, row -> {
-            assertEquals(1, row.getNumber("iterations").intValue());
-            assertEquals("weight", row.getString("weightProperty"));
-            assertEquals("partition", row.getString("partitionProperty"));
-            assertEquals("lpa", row.getString("writeProperty"));
-            assertTrue(row.getBoolean("write"));
-        });
-    }
-
-    @Test
     public void shouldTakeParametersFromConfig() {
         String query = "CALL algo.labelPropagation(null, null, null, {iterations:5,write:false,weightProperty:'score',partitionProperty:'key'})";
 
@@ -142,7 +131,7 @@ public class LabelPropagationProcIntegrationTest {
 
     @Test
     public void shouldRunLabelPropagation() {
-        String query = "CALL algo.labelPropagation(null, 'X', 'OUTGOING', {batchSize:$batchSize,concurrency:$concurrency})";
+        String query = "CALL algo.labelPropagation(null, 'X', 'OUTGOING', {batchSize:$batchSize,concurrency:$concurrency,graph:$graph})";
         String check = "MATCH (n) WHERE n.id IN [0,1] RETURN n.partition AS partition";
 
         runQuery(query, parParams(), row -> {
@@ -165,7 +154,7 @@ public class LabelPropagationProcIntegrationTest {
 
     @Test
     public void shouldFallbackToNodeIdsForNonExistingPartitionKey() {
-        String query = "CALL algo.labelPropagation(null, 'X', 'OUTGOING', {partitionProperty:'foobar',batchSize:$batchSize,concurrency:$concurrency})";
+        String query = "CALL algo.labelPropagation(null, 'X', 'OUTGOING', {partitionProperty:'foobar',batchSize:$batchSize,concurrency:$concurrency,graph:$graph})";
         String checkA = "MATCH (n) WHERE n.id = 0 RETURN n.foobar as partition";
         String checkB = "MATCH (n) WHERE n.id = 1 RETURN n.foobar as partition";
 
@@ -179,7 +168,7 @@ public class LabelPropagationProcIntegrationTest {
 
     @Test
     public void shouldFilterByLabel() {
-        String query = "CALL algo.labelPropagation('A', 'X', 'OUTGOING', {batchSize:$batchSize,concurrency:$concurrency})";
+        String query = "CALL algo.labelPropagation('A', 'X', 'OUTGOING', {batchSize:$batchSize,concurrency:$concurrency,graph:$graph})";
         String checkA = "MATCH (n) WHERE n.id = 0 RETURN n.partition as partition";
         String checkB = "MATCH (n) WHERE n.id = 1 RETURN n.partition as partition";
 
@@ -192,18 +181,12 @@ public class LabelPropagationProcIntegrationTest {
 
     @Test
     public void shouldPropagateIncoming() {
-        String query = "CALL algo.labelPropagation('A', 'X', 'INCOMING', {batchSize:$batchSize,concurrency:$concurrency})";
+        String query = "CALL algo.labelPropagation('A', 'X', 'INCOMING', {batchSize:$batchSize,concurrency:$concurrency,graph:$graph})";
         String check = "MATCH (n:A) WHERE n.id <> 0 RETURN n.partition as partition";
 
         runQuery(query, parParams());
         runQuery(check, row ->
                 assertEquals(42, row.getNumber("partition").intValue()));
-    }
-
-    @Test
-    public void shouldAllowHeavyGraph() {
-        String query = "CALL algo.labelPropagation(null, 'X', 'OUTGOING', {graph:'heavy',batchSize:$batchSize,concurrency:$concurrency})";
-        runQuery(query, parParams(), row -> assertEquals(12, row.getNumber("nodes").intValue()));
     }
 
     @Test
@@ -252,6 +235,6 @@ public class LabelPropagationProcIntegrationTest {
     }
 
     private Map<String, Object> parParams() {
-        return MapUtil.map("batchSize", parallel ? 1 : 100, "concurrency", parallel ? 1 : 8);
+        return MapUtil.map("batchSize", parallel ? 1 : 100, "concurrency", parallel ? 1 : 8, "graph", graphImpl);
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -235,6 +235,6 @@ public class LabelPropagationProcIntegrationTest {
     }
 
     private Map<String, Object> parParams() {
-        return MapUtil.map("batchSize", parallel ? 1 : 100, "concurrency", parallel ? 1 : 8, "graph", graphImpl);
+        return MapUtil.map("batchSize", parallel ? 1 : 100, "concurrency", parallel ? 8: 1, "graph", graphImpl);
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcIntegrationTest.java
@@ -213,24 +213,6 @@ public class LabelPropagationProcIntegrationTest {
     }
 
     @Test
-    public void shouldNotAllowLightOrHugeOrKernelGraph() throws Throwable {
-        String query = "CALL algo.labelPropagation(null, null, null, {graph:$graph})";
-        Map<String, Object> params = parParams();
-
-        exceptions.expect(IllegalArgumentException.class);
-        exceptions.expectMessage("The graph algorithm only supports these graph types; [heavy, cypher]");
-
-        for (final String graph : Arrays.asList("light", "huge", "kernel")) {
-            params.put("graph", graph);
-            try {
-                runQuery(query, params);
-            } catch (QueryExecutionException qee) {
-                throw Exceptions.rootCause(qee);
-            }
-        }
-    }
-
-    @Test
     public void shouldStreamResults() {
         // this one deliberately tests the streaming and non streaming versions against each other to check we get the same results
         // we intentionally start with no labels defined for any nodes (hence partitionProperty = {lpa, lpa2})

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcLoadPredefinedPartitionsTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LabelPropagationProcLoadPredefinedPartitionsTest.java
@@ -57,11 +57,13 @@ public class LabelPropagationProcLoadPredefinedPartitionsTest {
             "CREATE (f:F {id: 5, partition: 29})\n" +
             "CREATE (g:G {id: 6, partition: 29}) ";
 
-    @Parameterized.Parameters(name = "parallel={0}")
+    @Parameterized.Parameters(name = "parallel={0}, graph={1}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
-                new Object[]{false},
-                new Object[]{true}
+                new Object[]{false, "heavy"},
+                new Object[]{true, "heavy"},
+                new Object[]{false, "huge"},
+                new Object[]{true, "huge"}
         );
     }
 
@@ -71,9 +73,11 @@ public class LabelPropagationProcLoadPredefinedPartitionsTest {
     public ExpectedException exceptions = ExpectedException.none();
 
     private final boolean parallel;
+    private final String graphImpl;
 
-    public LabelPropagationProcLoadPredefinedPartitionsTest(boolean parallel) {
+    public LabelPropagationProcLoadPredefinedPartitionsTest(boolean parallel, String graphImpl) {
         this.parallel = parallel;
+        this.graphImpl = graphImpl;
     }
 
     @Before
@@ -99,7 +103,7 @@ public class LabelPropagationProcLoadPredefinedPartitionsTest {
 
     @Test
     public void shouldUseDefaultValues() {
-        String query = "CALL algo.labelPropagation.stream(null, null, {batchSize:$batchSize,concurrency:$concurrency}) " +
+        String query = "CALL algo.labelPropagation.stream(null, null, {batchSize:$batchSize,concurrency:$concurrency,graph:$graph}) " +
                 "YIELD nodeId, label " +
                 "RETURN algo.asNode(nodeId) AS id, label " +
                 "ORDER BY id";
@@ -112,6 +116,6 @@ public class LabelPropagationProcLoadPredefinedPartitionsTest {
     }
 
     private Map<String, Object> parParams() {
-        return MapUtil.map("batchSize", parallel ? 5 : 1, "concurrency", parallel ? 8 : 1);
+        return MapUtil.map("batchSize", parallel ? 5 : 1, "concurrency", parallel ? 8 : 1, "graph", graphImpl);
     }
 }

--- a/tests/src/test/java/org/neo4j/graphalgo/algo/LoadGraphProcIntegrationTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/algo/LoadGraphProcIntegrationTest.java
@@ -28,10 +28,7 @@ import org.junit.runners.Parameterized;
 import org.neo4j.graphalgo.LabelPropagationProc;
 import org.neo4j.graphalgo.LoadGraphProc;
 import org.neo4j.graphalgo.PageRankProc;
-import org.neo4j.graphalgo.api.HugeGraph;
-import org.neo4j.graphalgo.core.heavyweight.HeavyGraph;
 import org.neo4j.graphalgo.core.loading.LoadGraphFactory;
-import org.neo4j.graphalgo.core.neo4jview.GraphView;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
@@ -142,17 +139,10 @@ public class LoadGraphProcIntegrationTest {
         String query = "CALL algo.labelPropagation(null,null,null,{graph:$name,write:false})";
         try {
             runQuery(query, singletonMap("name", "foo"), row -> {
-                assertEquals(HeavyGraph.TYPE, graph);
                 assertEquals(12, row.getNumber("nodes").intValue());
             });
         } catch (QueryExecutionException qee) {
-            switch (graph) {
-                case GraphView.TYPE :
-                case HugeGraph.TYPE :
-                    assertEquals(true, qee.getMessage().contains("The graph algorithm only supports these graph types"));
-                    break;
-                default: fail("Error using wrong graph type:" + qee.getMessage());
-            }
+            fail("Error using wrong graph type:" + qee.getMessage());
         }
     }
 

--- a/tests/src/test/java/org/neo4j/graphalgo/core/huge/HugeGraphFactoryTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/huge/HugeGraphFactoryTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (c) 2017 "Neo4j, Inc." <http://neo4j.com>
+ *
+ * This file is part of Neo4j Graph Algorithms <http://github.com/neo4j-contrib/neo4j-graph-algorithms>.
+ *
+ * Neo4j Graph Algorithms is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphalgo.core.huge;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.graphalgo.PropertyMapping;
+import org.neo4j.graphalgo.api.HugeGraph;
+import org.neo4j.graphalgo.core.GraphLoader;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import java.util.Arrays;
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class HugeGraphFactoryTest {
+
+    @ClassRule
+    public static ImpermanentDatabaseRule DB = new ImpermanentDatabaseRule();
+
+    private static long id1;
+    private static long id2;
+    private static long id3;
+
+    @BeforeClass
+    public static void setup() {
+        DB.execute("CREATE " +
+                "(n1:Node1 {prop1: 1})," +
+                "(n2:Node2 {prop2: 2})," +
+                "(n3:Node3 {prop3: 3})" +
+                "CREATE " +
+                "(n1)-[:REL1 {prop1: 1}]->(n2)," +
+                "(n1)-[:REL2 {prop2: 2}]->(n3)," +
+                "(n2)-[:REL3 {prop3: 3}]->(n3);");
+        id1 = DB.execute("MATCH (n:Node1) RETURN id(n) AS id").<Long>columnAs("id").next();
+        id2 = DB.execute("MATCH (n:Node2) RETURN id(n) AS id").<Long>columnAs("id").next();
+        id3 = DB.execute("MATCH (n:Node3) RETURN id(n) AS id").<Long>columnAs("id").next();
+    }
+
+    @Test
+    public void testAnyLabel() {
+
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withAnyLabel()
+                .withAnyRelationshipType()
+                .load(HugeGraphFactory.class);
+
+        assertEquals(3L, graph.nodeCount());
+    }
+
+    @Test
+    public void testWithLabel() {
+
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withLabel("Node1")
+                .withoutRelationshipWeights()
+                .withAnyRelationshipType()
+                .load(HugeGraphFactory.class);
+
+        assertEquals(1L, graph.nodeCount());
+    }
+
+    @Test
+    public void testAnyRelation() {
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withAnyLabel()
+                .withoutRelationshipWeights()
+                .withAnyRelationshipType()
+                .load(HugeGraphFactory.class);
+
+        long[] out1 = collectTargetIds(graph, id1);
+        assertArrayEquals(expectedIds(graph, id2, id3), out1);
+
+        long[] out2 = collectTargetIds(graph, id2);
+        assertArrayEquals(expectedIds(graph, id3), out2);
+    }
+
+    @Test
+    public void testWithRelation() {
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withAnyLabel()
+                .withoutRelationshipWeights()
+                .withRelationshipType("REL1")
+                .load(HugeGraphFactory.class);
+
+        long[] out1 = collectTargetIds(graph, id1);
+        assertArrayEquals(expectedIds(graph, id2), out1);
+
+        long[] out2 = collectTargetIds(graph, id2);
+        assertArrayEquals(expectedIds(graph), out2);
+    }
+
+    @Test
+    public void testWithProperty() {
+
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withAnyLabel()
+                .withAnyRelationshipType()
+                .withRelationshipWeightsFromProperty("prop1", 0.0)
+                .load(HugeGraphFactory.class);
+
+        double[] out1 = collectTargetWeights(graph, id1);
+        assertArrayEquals(expectedWeights(1.0, 0.0), out1, 1e-4);
+    }
+
+    @Test
+    public void testWithNodeProperties() {
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withoutRelationshipWeights()
+                .withAnyRelationshipType()
+                .withOptionalNodeProperties(
+                        PropertyMapping.of("prop1", "prop1", 0D),
+                        PropertyMapping.of("prop2", "prop2", 0D),
+                        PropertyMapping.of("prop3", "prop3", 0D)
+                )
+                .load(HugeGraphFactory.class);
+
+        assertEquals(1.0, graph.nodeProperties("prop1").get(graph.toMappedNodeId(0L)), 0.01);
+        assertEquals(2.0, graph.nodeProperties("prop2").get(graph.toMappedNodeId(1L)), 0.01);
+        assertEquals(3.0, graph.nodeProperties("prop3").get(graph.toMappedNodeId(2L)), 0.01);
+    }
+
+    private long[] collectTargetIds(final HugeGraph graph, long sourceId) {
+        LongStream.Builder outIds = LongStream.builder();
+        graph.forEachRelationship(graph.toHugeMappedNodeId(sourceId), Direction.OUTGOING,
+                (sourceNodeId, targetNodeId) -> {
+                    outIds.add(targetNodeId);
+                    return true;
+                });
+        return outIds.build().sorted().toArray();
+    }
+
+    private double[] collectTargetWeights(final HugeGraph graph, long sourceId) {
+        DoubleStream.Builder outWeights = DoubleStream.builder();
+        graph.forEachRelationship(graph.toHugeMappedNodeId(sourceId), Direction.OUTGOING,
+                (sourceNodeId, targetNodeId, weight) -> {
+                    outWeights.add(weight);
+                    return true;
+                });
+        return outWeights.build().toArray();
+    }
+
+    private long[] expectedIds(final HugeGraph graph, long... expected) {
+        return Arrays.stream(expected).map(graph::toHugeMappedNodeId).sorted().toArray();
+    }
+
+    private double[] expectedWeights(double... expected) {
+        return expected;
+    }
+}

--- a/tests/src/test/java/org/neo4j/graphalgo/core/huge/HugeGraphFactoryTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/core/huge/HugeGraphFactoryTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.neo4j.graphalgo.PropertyMapping;
 import org.neo4j.graphalgo.api.HugeGraph;
 import org.neo4j.graphalgo.core.GraphLoader;
+import org.neo4j.graphalgo.core.huge.loader.HugeGraphFactory;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
@@ -139,6 +140,23 @@ public class HugeGraphFactoryTest {
         assertEquals(1.0, graph.nodeProperties("prop1").get(graph.toMappedNodeId(0L)), 0.01);
         assertEquals(2.0, graph.nodeProperties("prop2").get(graph.toMappedNodeId(1L)), 0.01);
         assertEquals(3.0, graph.nodeProperties("prop3").get(graph.toMappedNodeId(2L)), 0.01);
+    }
+
+    @Test
+    public void testWithHugeNodeProperties() {
+        final HugeGraph graph = (HugeGraph) new GraphLoader(DB)
+                .withoutRelationshipWeights()
+                .withAnyRelationshipType()
+                .withOptionalNodeProperties(
+                        PropertyMapping.of("prop1", "prop1", 0D),
+                        PropertyMapping.of("prop2", "prop2", 0D),
+                        PropertyMapping.of("prop3", "prop3", 0D)
+                )
+                .load(HugeGraphFactory.class);
+
+        assertEquals(1.0, graph.hugeNodeProperties("prop1").nodeWeight(graph.toHugeMappedNodeId(0L)), 0.01);
+        assertEquals(2.0, graph.hugeNodeProperties("prop2").nodeWeight(graph.toHugeMappedNodeId(1L)), 0.01);
+        assertEquals(3.0, graph.hugeNodeProperties("prop3").nodeWeight(graph.toHugeMappedNodeId(2L)), 0.01);
     }
 
     private long[] collectTargetIds(final HugeGraph graph, long sourceId) {

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/LabelPropagation420CypherLoadingTest.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/LabelPropagation420CypherLoadingTest.java
@@ -147,6 +147,7 @@ public final class LabelPropagation420CypherLoadingTest
     private void testClustering(int batchSize) throws Exception {
         final LabelPropagation lp = new LabelPropagation(
                 graph,
+                graph,
                 batchSize,
                 Pools.DEFAULT_CONCURRENCY,
                 Pools.DEFAULT);

--- a/tests/src/test/java/org/neo4j/graphalgo/impl/LabelPropagation420Test.java
+++ b/tests/src/test/java/org/neo4j/graphalgo/impl/LabelPropagation420Test.java
@@ -144,6 +144,7 @@ public final class LabelPropagation420Test {
     private void testClustering(int batchSize) throws Exception {
         final LabelPropagation lp = new LabelPropagation(
                 graph,
+                graph,
                 batchSize,
                 Pools.DEFAULT_CONCURRENCY,
                 Pools.DEFAULT);


### PR DESCRIPTION
This is not yet full huge support for LPA but allows for the huge graph to be used in case it isn't actually huge but can be used in places where a simple Graph is sufficient.
- Loading node weights and properties has been added to the huge graph
- LPA lifted its restriction to require the HeavyGraph and falls back to empty NodeWeights in case the graph does not support NodeWeights itself (GraphView should be the only one).
Since the node weight loading is added to the 'old' huge loading (without #771 ), I propose to add this first, so that I can rebase 771 and we can have the actual huge LPA later on with a smaller changeset.