### PR TITLE
Use floats instead of scaled ints for PR score

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/ArticleRankComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/ArticleRankComputeStep.java
@@ -41,7 +41,7 @@ final class ArticleRankComputeStep extends BaseComputeStep implements Relationsh
     }
 
 
-    private int srcRankDelta;
+    private float srcRankDelta;
 
 
     void singleIteration() {
@@ -53,7 +53,7 @@ final class ArticleRankComputeStep extends BaseComputeStep implements Relationsh
             if (delta > 0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * (delta / (degree + averageDegree)));
+                    srcRankDelta = (float) (delta / (degree + averageDegree));
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }
@@ -61,7 +61,7 @@ final class ArticleRankComputeStep extends BaseComputeStep implements Relationsh
     }
 
     public boolean accept(int sourceNodeId, int targetNodeId, long relationId) {
-        if (srcRankDelta != 0) {
+        if (srcRankDelta != 0f) {
             int idx = binaryLookup(targetNodeId, starts);
             nextScores[idx][targetNodeId - starts[idx]] += srcRankDelta;
         }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/BaseComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/BaseComputeStep.java
@@ -42,7 +42,7 @@ public abstract class BaseComputeStep implements ComputeStep {
     double[] pageRank;
     double[] deltas;
     float[][] nextScores;
-    private float[][] prevScores;
+    float[][] prevScores;
 
     final int partitionSize;
     final int startNode;
@@ -76,7 +76,7 @@ public abstract class BaseComputeStep implements ComputeStep {
             singleIteration();
             state = S_SYNC;
         } else if (state == S_SYNC) {
-            synchronizeScores(combineScores());
+            combineScores();
             state = S_NORM;
         } else if(state == S_NORM) {
             normalizeDeltas();
@@ -130,36 +130,25 @@ public abstract class BaseComputeStep implements ComputeStep {
         this.prevScores = prevScores;
     }
 
-    private float[] combineScores() {
+    void combineScores() {
         assert prevScores != null;
         assert prevScores.length >= 1;
-        float[][] prevScores = this.prevScores;
 
-        int length = prevScores.length;
-        float[] allScores = prevScores[0];
-        for (int i = 1; i < length; i++) {
-            float[] scores = prevScores[i];
-            for (int j = 0; j < scores.length; j++) {
-                allScores[j] += scores[j];
-                scores[j] = 0f;
-            }
-        }
-
-        return allScores;
-    }
-
-    void synchronizeScores(float[] allScores) {
         double dampingFactor = this.dampingFactor;
         double[] pageRank = this.pageRank;
+        double[] deltas = this.deltas;
+        float[][] prevScores = this.prevScores;
+        int length = prevScores[0].length;
 
-        int length = allScores.length;
         for (int i = 0; i < length; i++) {
-            float sum = allScores[i];
-
-            double delta = dampingFactor * (double) sum;
+            double sum = 0.0;
+            for (float[] scores : prevScores) {
+                sum += (double) scores[i];
+                scores[i] = 0f;
+            }
+            double delta = dampingFactor * sum;
             pageRank[i] += delta;
             deltas[i] = delta;
-            allScores[i] = 0f;
         }
     }
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/BaseComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/BaseComputeStep.java
@@ -41,8 +41,8 @@ public abstract class BaseComputeStep implements ComputeStep {
 
     double[] pageRank;
     double[] deltas;
-    int[][] nextScores;
-    private int[][] prevScores;
+    float[][] nextScores;
+    private float[][] prevScores;
 
     final int partitionSize;
     final int startNode;
@@ -65,7 +65,7 @@ public abstract class BaseComputeStep implements ComputeStep {
         state = S_INIT;
     }
 
-    public void setStarts(int starts[], int[] lengths) {
+    public void setStarts(int[] starts, int[] lengths) {
         this.starts = starts;
         this.lengths = lengths;
     }
@@ -90,8 +90,8 @@ public abstract class BaseComputeStep implements ComputeStep {
     void normalizeDeltas() {}
 
     private void initialize() {
-        this.nextScores = new int[starts.length][];
-        Arrays.setAll(nextScores, i -> new int[lengths[i]]);
+        this.nextScores = new float[starts.length][];
+        Arrays.setAll(nextScores, i -> new float[lengths[i]]);
 
         double[] partitionRank = new double[partitionSize];
 
@@ -99,7 +99,7 @@ public abstract class BaseComputeStep implements ComputeStep {
         if(sourceNodeIds.length == 0) {
             Arrays.fill(partitionRank, initialValue);
         } else {
-            Arrays.fill(partitionRank,0);
+            Arrays.fill(partitionRank, 0.0);
 
             int[] partitionSourceNodeIds = IntStream.of(sourceNodeIds)
                     .filter(sourceNodeId -> sourceNodeId >= startNode && sourceNodeId < endNode)
@@ -126,45 +126,45 @@ public abstract class BaseComputeStep implements ComputeStep {
         this.l2Norm = l2Norm;
     }
 
-    public void prepareNextIteration(int[][] prevScores) {
+    public void prepareNextIteration(float[][] prevScores) {
         this.prevScores = prevScores;
     }
 
-    private int[] combineScores() {
+    private float[] combineScores() {
         assert prevScores != null;
         assert prevScores.length >= 1;
-        int[][] prevScores = this.prevScores;
+        float[][] prevScores = this.prevScores;
 
         int length = prevScores.length;
-        int[] allScores = prevScores[0];
+        float[] allScores = prevScores[0];
         for (int i = 1; i < length; i++) {
-            int[] scores = prevScores[i];
+            float[] scores = prevScores[i];
             for (int j = 0; j < scores.length; j++) {
                 allScores[j] += scores[j];
-                scores[j] = 0;
+                scores[j] = 0f;
             }
         }
 
         return allScores;
     }
 
-    void synchronizeScores(int[] allScores) {
+    void synchronizeScores(float[] allScores) {
         double dampingFactor = this.dampingFactor;
         double[] pageRank = this.pageRank;
 
         int length = allScores.length;
         for (int i = 0; i < length; i++) {
-            int sum = allScores[i];
+            float sum = allScores[i];
 
-            double delta = dampingFactor * (sum / 100_000.0);
+            double delta = dampingFactor * (double) sum;
             pageRank[i] += delta;
             deltas[i] = delta;
-            allScores[i] = 0;
+            allScores[i] = 0f;
         }
     }
 
     @Override
-    public int[][] nextScores() {
+    public float[][] nextScores() {
         return nextScores;
     }
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/ComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/ComputeStep.java
@@ -19,7 +19,7 @@
 package org.neo4j.graphalgo.impl.pagerank;
 
 public interface ComputeStep extends Runnable {
-    int[][] nextScores();
+    float[][] nextScores();
 
     double[] pageRank();
 
@@ -27,7 +27,7 @@ public interface ComputeStep extends Runnable {
 
     void setStarts(int[] startArray, int[] lengthArray);
 
-    void prepareNextIteration(int[][] score);
+    void prepareNextIteration(float[][] score);
 
     void prepareNormalizeDeltas(double l2Norm, int iteration);
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/EigenvectorCentralityComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/EigenvectorCentralityComputeStep.java
@@ -23,9 +23,6 @@ import org.neo4j.graphalgo.api.RelationshipConsumer;
 import org.neo4j.graphalgo.api.RelationshipIterator;
 import org.neo4j.graphdb.Direction;
 
-import java.util.Arrays;
-import java.util.stream.IntStream;
-
 import static org.neo4j.graphalgo.core.utils.ArrayUtil.binaryLookup;
 
 final class EigenvectorCentralityComputeStep extends BaseComputeStep implements RelationshipConsumer {
@@ -45,7 +42,7 @@ final class EigenvectorCentralityComputeStep extends BaseComputeStep implements 
         this.initialValue = 1.0 / nodeCount;
     }
 
-    private int srcRankDelta;
+    private float srcRankDelta;
 
 
     void singleIteration() {
@@ -54,10 +51,10 @@ final class EigenvectorCentralityComputeStep extends BaseComputeStep implements 
         RelationshipIterator rels = this.relationshipIterator;
         for (int nodeId = startNode; nodeId < endNode; ++nodeId) {
             double delta = deltas[nodeId - startNode];
-            if (delta > 0) {
+            if (delta > 0.0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * delta);
+                    srcRankDelta = (float) delta;
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }
@@ -66,7 +63,7 @@ final class EigenvectorCentralityComputeStep extends BaseComputeStep implements 
 
     @Override
     public boolean accept(int sourceNodeId, int targetNodeId, long relationId) {
-        if (srcRankDelta != 0) {
+        if (srcRankDelta != 0f) {
             int idx = binaryLookup(targetNodeId, starts);
             nextScores[idx][targetNodeId - starts[idx]] += srcRankDelta;
         }
@@ -79,17 +76,15 @@ final class EigenvectorCentralityComputeStep extends BaseComputeStep implements 
     }
 
     @Override
-    void synchronizeScores(int[] allScores) {
+    void synchronizeScores(float[] allScores) {
         double[] pageRank = this.pageRank;
 
         int length = allScores.length;
         for (int i = 0; i < length; i++) {
-            int sum = allScores[i];
-
-            double delta = sum / 100_000.0;
-            pageRank[i] += delta;
-            deltas[i] = delta;
-            allScores[i] = 0;
+            double sum = (double) allScores[i];
+            pageRank[i] += sum;
+            deltas[i] = sum;
+            allScores[i] = 0f;
         }
 
     }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/EigenvectorCentralityComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/EigenvectorCentralityComputeStep.java
@@ -76,17 +76,24 @@ final class EigenvectorCentralityComputeStep extends BaseComputeStep implements 
     }
 
     @Override
-    void synchronizeScores(float[] allScores) {
+    void combineScores() {
+        assert prevScores != null;
+        assert prevScores.length >= 1;
+
         double[] pageRank = this.pageRank;
+        double[] deltas = this.deltas;
+        float[][] prevScores = this.prevScores;
+        int length = prevScores[0].length;
 
-        int length = allScores.length;
         for (int i = 0; i < length; i++) {
-            double sum = (double) allScores[i];
-            pageRank[i] += sum;
-            deltas[i] = sum;
-            allScores[i] = 0f;
+            double delta = 0.0;
+            for (float[] scores : prevScores) {
+                delta += (double) scores[i];
+                scores[i] = 0f;
+            }
+            pageRank[i] += delta;
+            deltas[i] = delta;
         }
-
     }
 
     @Override

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeArticleRankComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeArticleRankComputeStep.java
@@ -49,7 +49,7 @@ final class HugeArticleRankComputeStep extends HugeBaseComputeStep implements Hu
     }
 
 
-    private int srcRankDelta;
+    private float srcRankDelta;
 
 
     void singleIteration() {
@@ -61,7 +61,7 @@ final class HugeArticleRankComputeStep extends HugeBaseComputeStep implements Hu
             if (delta > 0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * (delta / (degree + averageDegree)));
+                    srcRankDelta = (float) (delta / (degree + averageDegree));
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }
@@ -69,7 +69,7 @@ final class HugeArticleRankComputeStep extends HugeBaseComputeStep implements Hu
     }
 
     public boolean accept(long sourceNodeId, long targetNodeId) {
-        if (srcRankDelta != 0) {
+        if (srcRankDelta != 0f) {
             int idx = binaryLookup(targetNodeId, starts);
             nextScores[idx][(int) (targetNodeId - starts[idx])] += srcRankDelta;
         }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeBaseComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeBaseComputeStep.java
@@ -145,7 +145,7 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
         this.prevScores = prevScores;
     }
 
-    private void combineScores() {
+    void combineScores() {
         assert prevScores != null;
         assert prevScores.length >= 1;
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeBaseComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeBaseComputeStep.java
@@ -20,16 +20,13 @@ package org.neo4j.graphalgo.impl.pagerank;
 
 import org.neo4j.graphalgo.api.HugeDegrees;
 import org.neo4j.graphalgo.api.HugeRelationshipIterator;
-import org.neo4j.graphalgo.api.HugeRelationshipWeights;
 import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
-import org.neo4j.graphdb.Direction;
 
 import java.util.Arrays;
 import java.util.stream.LongStream;
 
-import static org.neo4j.graphalgo.core.utils.ArrayUtil.binaryLookup;
 import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfDoubleArray;
-import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfIntArray;
+import static org.neo4j.graphalgo.core.utils.paged.MemoryUsage.sizeOfFloatArray;
 
 public abstract class HugeBaseComputeStep implements HugeComputeStep {
     private static final int S_INIT = 0;
@@ -51,8 +48,8 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
 
     double[] pageRank;
     double[] deltas;
-    int[][] nextScores;
-    int[][] prevScores;
+    float[][] nextScores;
+    float[][] prevScores;
 
     final long startNode;
     final long endNode;
@@ -104,11 +101,11 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
     void normalizeDeltas() {}
 
     private void initialize() {
-        this.nextScores = new int[starts.length][];
+        this.nextScores = new float[starts.length][];
         Arrays.setAll(nextScores, i -> {
             int size = lengths[i];
-            tracker.add(sizeOfIntArray(size));
-            return new int[size];
+            tracker.add(sizeOfFloatArray(size));
+            return new float[size];
         });
 
         tracker.add(sizeOfDoubleArray(partitionSize) << 1);
@@ -118,7 +115,7 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
         if(sourceNodeIds.length == 0) {
             Arrays.fill(partitionRank, initialValue);
         } else {
-            Arrays.fill(partitionRank,0);
+            Arrays.fill(partitionRank,0.0);
 
             long[] partitionSourceNodeIds = LongStream.of(sourceNodeIds)
                     .filter(sourceNodeId -> sourceNodeId >= startNode && sourceNodeId < endNode)
@@ -144,7 +141,7 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
         this.l2Norm = l2Norm;
     }
 
-    public void prepareNextIteration(int[][] prevScores) {
+    public void prepareNextIteration(float[][] prevScores) {
         this.prevScores = prevScores;
     }
 
@@ -153,23 +150,23 @@ public abstract class HugeBaseComputeStep implements HugeComputeStep {
         assert prevScores.length >= 1;
 
         int scoreDim = prevScores.length;
-        int[][] prevScores = this.prevScores;
+        float[][] prevScores = this.prevScores;
 
         int length = prevScores[0].length;
         for (int i = 0; i < length; i++) {
-            int sum = 0;
+            double sum = 0.0;
             for (int j = 0; j < scoreDim; j++) {
-                int[] scores = prevScores[j];
-                sum += scores[i];
-                scores[i] = 0;
+                float[] scores = prevScores[j];
+                sum += (double) scores[i];
+                scores[i] = 0f;
             }
-            double delta = dampingFactor * (sum / 100_000.0);
+            double delta = dampingFactor * sum;
             pageRank[i] += delta;
             deltas[i] = delta;
         }
     }
 
-    public int[][] nextScores() {
+    public float[][] nextScores() {
         return nextScores;
     }
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeComputeStep.java
@@ -23,9 +23,9 @@ public interface HugeComputeStep extends Runnable {
 
     long[] starts();
 
-    void prepareNextIteration(int[][] score);
+    void prepareNextIteration(float[][] score);
 
-    int[][] nextScores();
+    float[][] nextScores();
 
     void setStarts(long[] startArray, int[] lengthArray);
 

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeEigenvectorCentralityComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeEigenvectorCentralityComputeStep.java
@@ -80,6 +80,27 @@ final class HugeEigenvectorCentralityComputeStep extends HugeBaseComputeStep imp
     }
 
     @Override
+    void combineScores() {
+        assert prevScores != null;
+        assert prevScores.length >= 1;
+
+        double[] pageRank = this.pageRank;
+        double[] deltas = this.deltas;
+        float[][] prevScores = this.prevScores;
+        int length = prevScores[0].length;
+
+        for (int i = 0; i < length; i++) {
+            double delta = 0.0;
+            for (float[] scores : prevScores) {
+                delta += (double) scores[i];
+                scores[i] = 0f;
+            }
+            pageRank[i] += delta;
+            deltas[i] = delta;
+        }
+    }
+
+    @Override
     void normalizeDeltas() {
         for (int i = 0; i < deltas.length; i++) {
             deltas[i] = deltas[i] / l2Norm;

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeEigenvectorCentralityComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeEigenvectorCentralityComputeStep.java
@@ -24,12 +24,10 @@ import org.neo4j.graphalgo.api.HugeRelationshipIterator;
 import org.neo4j.graphalgo.core.utils.paged.AllocationTracker;
 import org.neo4j.graphdb.Direction;
 
-import java.util.Arrays;
-
 import static org.neo4j.graphalgo.core.utils.ArrayUtil.binaryLookup;
 
 final class HugeEigenvectorCentralityComputeStep extends HugeBaseComputeStep implements HugeRelationshipConsumer {
-    private int srcRankDelta;
+    private float srcRankDelta;
     private final double initialValue;
 
     HugeEigenvectorCentralityComputeStep(
@@ -62,10 +60,10 @@ final class HugeEigenvectorCentralityComputeStep extends HugeBaseComputeStep imp
         HugeRelationshipIterator rels = this.relationshipIterator;
         for (long nodeId = startNode; nodeId < endNode; ++nodeId) {
             double delta = deltas[(int) (nodeId - startNode)];
-            if (delta > 0) {
+            if (delta > 0.0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * delta);
+                    srcRankDelta = (float) delta;
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }
@@ -74,7 +72,7 @@ final class HugeEigenvectorCentralityComputeStep extends HugeBaseComputeStep imp
 
     @Override
     public boolean accept(long sourceNodeId, long targetNodeId) {
-        if (srcRankDelta != 0) {
+        if (srcRankDelta != 0f) {
             int idx = binaryLookup(targetNodeId, starts);
             nextScores[idx][(int) (targetNodeId - starts[idx])] += srcRankDelta;
         }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeNonWeightedComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeNonWeightedComputeStep.java
@@ -26,7 +26,7 @@ import static org.neo4j.graphalgo.core.utils.ArrayUtil.binaryLookup;
 
 public class HugeNonWeightedComputeStep extends HugeBaseComputeStep implements HugeRelationshipConsumer {
 
-    private int srcRankDelta;
+    private float srcRankDelta;
 
     HugeNonWeightedComputeStep(
             double dampingFactor,
@@ -51,10 +51,10 @@ public class HugeNonWeightedComputeStep extends HugeBaseComputeStep implements H
         HugeRelationshipIterator rels = this.relationshipIterator;
         for (long nodeId = startNode; nodeId < endNode; ++nodeId) {
             double delta = deltas[(int) (nodeId - startNode)];
-            if (delta > 0) {
+            if (delta > 0.0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * (delta / degree));
+                    srcRankDelta = (float) (delta / degree);
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }
@@ -63,7 +63,7 @@ public class HugeNonWeightedComputeStep extends HugeBaseComputeStep implements H
 
     @Override
     public boolean accept(long sourceNodeId, long targetNodeId) {
-        if (srcRankDelta != 0) {
+        if (srcRankDelta != 0f) {
             int idx = binaryLookup(targetNodeId, starts);
             nextScores[idx][(int) (targetNodeId - starts[idx])] += srcRankDelta;
         }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeWeightedComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/HugeWeightedComputeStep.java
@@ -60,7 +60,7 @@ public class HugeWeightedComputeStep extends HugeBaseComputeStep implements Huge
         HugeRelationshipIterator rels = this.relationshipIterator;
         for (long nodeId = startNode; nodeId < endNode; ++nodeId) {
             delta = deltas[(int) (nodeId - startNode)];
-            if (delta > 0) {
+            if (delta > 0.0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
                     sumOfWeights = aggregatedDegrees[(int) nodeId];
@@ -76,8 +76,8 @@ public class HugeWeightedComputeStep extends HugeBaseComputeStep implements Huge
 
         if (weight > 0) {
             double proportion = weight / sumOfWeights;
-            int srcRankDelta = (int) (100_000 * (delta * proportion));
-            if (srcRankDelta != 0) {
+            float srcRankDelta = (float) (delta * proportion);
+            if (srcRankDelta != 0f) {
                 int idx = binaryLookup(targetNodeId, starts);
                 nextScores[idx][(int) (targetNodeId - starts[idx])] += srcRankDelta;
             }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/NonWeightedComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/NonWeightedComputeStep.java
@@ -41,7 +41,7 @@ final class NonWeightedComputeStep extends BaseComputeStep implements Relationsh
     }
 
 
-    private int srcRankDelta;
+    private float srcRankDelta;
 
 
     void singleIteration() {
@@ -53,7 +53,7 @@ final class NonWeightedComputeStep extends BaseComputeStep implements Relationsh
             if (delta > 0) {
                 int degree = degrees.degree(nodeId, Direction.OUTGOING);
                 if (degree > 0) {
-                    srcRankDelta = (int) (100_000 * (delta / degree));
+                    srcRankDelta = (float) (delta / degree);
                     rels.forEachRelationship(nodeId, Direction.OUTGOING, this);
                 }
             }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/PageRank.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/PageRank.java
@@ -92,7 +92,7 @@ public class PageRank extends Algorithm<PageRank> implements PageRankAlgorithm {
 
     /**
      * Forces sequential use. If you want parallelism, prefer
-     * {@link #PageRank(ExecutorService, int, int, IdMapping, NodeIterator, RelationshipIterator, Degrees, double)}
+     * {@link #PageRank(ExecutorService, int, int, Graph, double, LongStream, PageRankVariant)}
      */
     PageRank(Graph graph,
              double dampingFactor,
@@ -320,7 +320,7 @@ public class PageRank extends Algorithm<PageRank> implements PageRankAlgorithm {
         private final int concurrency;
         private List<ComputeStep> steps;
         private final ExecutorService pool;
-        private int[][][] scores;
+        private float[][][] scores;
 
         private ComputeSteps(
                 int concurrency,
@@ -331,8 +331,8 @@ public class PageRank extends Algorithm<PageRank> implements PageRankAlgorithm {
             this.steps = steps;
             this.pool = pool;
             int stepSize = steps.size();
-            scores = new int[stepSize][][];
-            Arrays.setAll(scores, i -> new int[stepSize][]);
+            scores = new float[stepSize][][];
+            Arrays.setAll(scores, i -> new float[stepSize][]);
         }
 
         CentralityResult getPageRank() {
@@ -389,7 +389,7 @@ public class PageRank extends Algorithm<PageRank> implements PageRankAlgorithm {
 
         private void synchronizeScores() {
             int numberOfSteps = steps.size();
-            int[][][] scores = this.scores;
+            float[][][] scores = this.scores;
             int stepIndex;
             for (stepIndex = 0; stepIndex < numberOfSteps; stepIndex++) {
                 synchronizeScoresForStep(steps.get(stepIndex), stepIndex, scores);
@@ -399,9 +399,9 @@ public class PageRank extends Algorithm<PageRank> implements PageRankAlgorithm {
         private void synchronizeScoresForStep(
                 ComputeStep step,
                 int idx,
-                int[][][] scores) {
+                float[][][] scores) {
             step.prepareNextIteration(scores[idx]);
-            int[][] nextScores = step.nextScores();
+            float[][] nextScores = step.nextScores();
             for (int j = 0, len = nextScores.length; j < len; j++) {
                 scores[j][idx] = nextScores[j];
             }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/WeightedComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/WeightedComputeStep.java
@@ -69,8 +69,8 @@ final class WeightedComputeStep extends BaseComputeStep implements WeightedRelat
     public boolean accept(int sourceNodeId, int targetNodeId, long relationId, double weight) {
         if (weight > 0) {
             double proportion = weight / sumOfWeights;
-            int srcRankDelta = (int) (100_000 * (delta * proportion));
-            if (srcRankDelta != 0) {
+            float srcRankDelta = (float) (delta * proportion);
+            if (srcRankDelta != 0f) {
                 int idx = binaryLookup(targetNodeId, starts);
                 nextScores[idx][targetNodeId - starts[idx]] += srcRankDelta;
             }

--- a/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/WeightedWithCachedWeightsComputeStep.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/impl/pagerank/WeightedWithCachedWeightsComputeStep.java
@@ -70,8 +70,8 @@ final class WeightedWithCachedWeightsComputeStep extends BaseComputeStep impleme
     public boolean accept(int sourceNodeId, int targetNodeId, long relationId, double weight) {
         if (weight > 0) {
             double proportion = weight / sumOfWeights;
-            int srcRankDelta = (int) (100_000 * (delta * proportion));
-            if (srcRankDelta != 0) {
+            float srcRankDelta = (float) (delta * proportion);
+            if (srcRankDelta != 0f) {
                 int idx = binaryLookup(targetNodeId, starts);
                 nextScores[idx][targetNodeId - starts[idx]] += srcRankDelta;
             }

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/LongIteratorsBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/LongIteratorsBenchmark.java
@@ -2,7 +2,7 @@ package org.neo4j.graphalgo.bench;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphalgo.core.huge.HugeIdMap;
+import org.neo4j.graphalgo.core.huge.loader.HugeIdMap;
 import org.neo4j.graphalgo.core.utils.RandomLongIterator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/PageRankBenchmarkLdbc.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/PageRankBenchmarkLdbc.java
@@ -26,7 +26,6 @@ import org.neo4j.graphalgo.helper.ldbc.LdbcDownloader;
 import org.neo4j.graphalgo.impl.pagerank.PageRankAlgorithm;
 import org.neo4j.graphalgo.impl.results.CentralityResult;
 import org.neo4j.graphdb.Direction;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.openjdk.jmh.annotations.*;
 
@@ -35,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
 
 @Threads(1)
-@Fork(value = 3, jvmArgs = {"-Xms8g", "-Xmx8g", "-XX:+UseG1GC"})
+@Fork(value = 1, jvmArgs = {"-Xms8g", "-Xmx8g", "-XX:+UseG1GC"})
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 2)
 @State(Scope.Benchmark)
@@ -43,20 +42,16 @@ import java.util.stream.LongStream;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class PageRankBenchmarkLdbc {
 
-//    @Param({"HEAVY", "HUGE"})
-    @Param({"HEAVY"})
+    @Param({"HEAVY", "HUGE"})
     GraphImpl graph;
 
-//    @Param({"true", "false"})
-    @Param({"false"})
+    @Param({"true"})
     boolean parallel;
 
-//    @Param({"L01", "L10"})
     @Param({"L01"})
     String graphId;
 
     @Param({"5"})
-//    @Param({"5", "20"})
     int iterations;
 
     private GraphDatabaseAPI db;
@@ -64,7 +59,7 @@ public class PageRankBenchmarkLdbc {
     private int batchSize;
 
     @Setup
-    public void setup() throws KernelException, IOException {
+    public void setup() throws IOException {
         db = LdbcDownloader.openDb(graphId);
         grph = new GraphLoader(db, Pools.DEFAULT)
                 .withDirection(Direction.OUTGOING)
@@ -81,7 +76,7 @@ public class PageRankBenchmarkLdbc {
     }
 
     @Benchmark
-    public CentralityResult run() throws Exception {
+    public CentralityResult run() {
         return PageRankAlgorithm.of(
                 AllocationTracker.EMPTY,
                 grph,


### PR DESCRIPTION
Potential solution for #861 

Benchmarks show a decrease in performance of 0.5 to 1%, well within the error margin.

<img width="665" alt="heavy-pr-diff-1" src="https://user-images.githubusercontent.com/633183/55402620-2e112480-5554-11e9-9d3b-f4a95ddec50a.png">
<img width="652" alt="huge-pr-diff-1" src="https://user-images.githubusercontent.com/633183/55402621-2ea9bb00-5554-11e9-834d-3cc894295188.png">

Benchmarks were executed as 
```
java -jar benchmark/target/benchmark.jar -rf json -rff page-rank.json -gc true -prof gc org.neo4j.graphalgo.bench.PageRankBenchmarkLdbc.*
```

Benchmark Json files:

[bechmark-files.zip](https://github.com/neo4j-contrib/neo4j-graph-algorithms/files/3033906/bechmark-files.zip)
