### PR TITLE
Add FlameGraph profiler to generate flame graphs of JMH benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,7 @@ env:
 language: java
 
 jdk:
-  - oraclejdk8
-
-before_install:
-  - sudo add-apt-repository -y ppa:webupd8team/java
-  - sudo apt-get update
-  - sudo apt-get install -y oracle-java8-installer || true
-  # todo remove the above `|| true` and all of the following once the ppa is fixed
-  - cd /var/lib/dpkg/info
-  - sudo sed -i 's|JAVA_VERSION=8u171|JAVA_VERSION=8u181|' oracle-java8-installer.*
-  - sudo sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u171-b11/512cd62ec5174c3487ac17c61aaa89e8/|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u181-b13/96a7b8442fe848ef90c96a2fad6ed6d1/|' oracle-java8-installer.*
-  - sudo sed -i 's|SHA256SUM_TGZ="b6dd2837efaaec4109b36cfbb94a774db100029f98b0d78be68c27bec0275982"|SHA256SUM_TGZ="1845567095bfbfebd42ed0d09397939796d05456290fb20a83c476ba09f991d3"|' oracle-java8-installer.*
-  - sudo sed -i 's|J_DIR=jdk1.8.0_171|J_DIR=jdk1.8.0_181|' oracle-java8-installer.*
-  - sudo apt-get update
-  - sudo apt-get install -y oracle-java8-installer
-  - cd $TRAVIS_BUILD_DIR
+  - openjdk8
 
 before_deploy:
   - git clone --depth 1 --branch benchmark-results https://github.com/neo4j-contrib/neo4j-graph-algorithms.git benchmark/results

--- a/benchmark/src/main/java/org/neo4j/graphalgo/bench/LongIteratorsBenchmark.java
+++ b/benchmark/src/main/java/org/neo4j/graphalgo/bench/LongIteratorsBenchmark.java
@@ -2,7 +2,7 @@ package org.neo4j.graphalgo.bench;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphalgo.core.huge.HugeIdMap;
+import org.neo4j.graphalgo.core.huge.loader.HugeIdMap;
 import org.neo4j.graphalgo.core.utils.RandomLongIterator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
+++ b/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
@@ -1,0 +1,323 @@
+package org.neo4j.prof;
+
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import org.neo4j.graphalgo.helper.ldbc.LdbcDownloader;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.IterationParams;
+import org.openjdk.jmh.profile.ExternalProfiler;
+import org.openjdk.jmh.profile.InternalProfiler;
+import org.openjdk.jmh.profile.ProfilerException;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.IterationResult;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.runner.IterationType;
+import org.openjdk.jmh.util.Utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public final class FlameGraph implements InternalProfiler, ExternalProfiler {
+
+    private static final String ASYNC_PROFILER_DIR = "ASYNC_PROFILER_DIR";
+    private static final String DEFAULT_EVENT = "cpu";
+
+    private final String event;
+    private final Path asyncProfilerDir;
+    private final boolean threads;
+    private final OptionalLong frameBufferSize;
+    private final OptionalLong interval;
+    private final Collection<Path> generated = new ArrayList<>();
+    private Path outputDir;
+    private boolean started;
+    private int measurementIterationCount;
+
+    public FlameGraph(final String initLine) throws ProfilerException {
+        Path asyncDir = null;
+        String env = System.getenv(ASYNC_PROFILER_DIR);
+        if (env != null) {
+            asyncDir = Paths.get(env).toAbsolutePath();
+        }
+
+        OptionParser parser = new OptionParser();
+
+        OptionSpec<String> outputDir = parser
+                .accepts("dir", "Output directory")
+                .withRequiredArg()
+                .describedAs("directory")
+                .ofType(String.class);
+
+        ArgumentAcceptingOptionSpec<String> asyncProfiler = parser
+                .accepts(
+                        "asyncProfiler",
+                        "Location of https://github.com/jvm-profiling-tools/async-profiler unless procived by $" + ASYNC_PROFILER_DIR)
+                .withRequiredArg()
+                .ofType(String.class)
+                .describedAs("directory");
+        if (asyncDir == null) {
+            asyncProfiler.required();
+        } else {
+            asyncProfiler.defaultsTo(asyncDir.toString());
+        }
+
+        OptionSpec<String> event = parser
+                .accepts("event", "Event to sample: cpu, alloc, lock, cache-misses etc.")
+                .withRequiredArg()
+                .ofType(String.class)
+                .defaultsTo("cpu");
+        OptionSpec<Long> frameBufferSize = parser
+                .accepts("framebuf", "Size of profiler framebuffer")
+                .withRequiredArg()
+                .ofType(Long.class);
+        OptionSpec<Long> interval = parser
+                .accepts("interval", "Profiling interval, in nanoseconds")
+                .withRequiredArg()
+                .ofType(Long.class);
+        OptionSpec<Boolean> threads = parser
+                .accepts("threads", "Profile threads separately")
+                .withRequiredArg()
+                .ofType(Boolean.class)
+                .defaultsTo(false, true);
+
+
+        OptionSet options = parseInitLine(initLine, parser);
+        if (options.has(event)) {
+            this.event = options.valueOf(event);
+        } else {
+            this.event = DEFAULT_EVENT;
+        }
+        if (options.has(frameBufferSize)) {
+            this.frameBufferSize = OptionalLong.of(options.valueOf(frameBufferSize));
+        } else {
+            this.frameBufferSize = OptionalLong.empty();
+        }
+        if (options.has(interval)) {
+            this.interval = OptionalLong.of(options.valueOf(interval));
+        } else {
+            this.interval = OptionalLong.empty();
+        }
+        if (options.has(outputDir)) {
+            this.outputDir = Paths.get(options.valueOf(outputDir));
+            createOutputDirectories();
+        }
+        if (options.has(threads)) {
+            this.threads = options.valueOf(threads);
+        } else {
+            this.threads = false;
+        }
+        if (options.has(asyncProfiler)) {
+            this.asyncProfilerDir = Paths.get(options.valueOf(asyncProfiler));
+        } else {
+            this.asyncProfilerDir = Objects.requireNonNull(asyncDir, "directory of async-profiler missing");
+        }
+    }
+
+    @Override
+    public Collection<String> addJVMInvokeOptions(final BenchmarkParams params) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<String> addJVMOptions(final BenchmarkParams params) {
+        return Arrays.asList(
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:+DebugNonSafepoints"
+        );
+    }
+
+    @Override
+    public String getDescription() {
+        return "Generate flame graphs using async-profiler";
+    }
+
+    @Override
+    public void beforeTrial(final BenchmarkParams benchmarkParams) {
+    }
+
+    @Override
+    public Collection<? extends Result> afterTrial(
+            final BenchmarkResult br,
+            final long pid,
+            final File stdOut,
+            final File stdErr) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean allowPrintOut() {
+        return true;
+    }
+
+    @Override
+    public boolean allowPrintErr() {
+        return true;
+    }
+
+    @Override
+    public void beforeIteration(final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {
+        if (iterationParams.getType() != IterationType.MEASUREMENT || started) {
+            return;
+        }
+
+        if (outputDir == null) {
+            outputDir = createTempDir(benchmarkParams);
+        }
+
+        Collection<String> commands = new ArrayList<>();
+        commands.add("-e");
+        commands.add(event);
+        if (threads) {
+            commands.add("-t");
+        }
+        frameBufferSize.ifPresent(b -> {
+            commands.add("-b");
+            commands.add(String.valueOf(b));
+        });
+        interval.ifPresent(i -> {
+            commands.add("-i");
+            commands.add(String.valueOf(i));
+        });
+        commands.add("-f");
+        commands.add(outputFile(benchmarkParams).toString());
+
+        profilerCommand("start", commands);
+        started = true;
+    }
+
+    @Override
+    public Collection<? extends Result> afterIteration(
+            final BenchmarkParams benchmarkParams,
+            final IterationParams iterationParams,
+            final IterationResult result) {
+        if (iterationParams.getType() != IterationType.MEASUREMENT) {
+            return Collections.emptyList();
+        }
+
+        if (++measurementIterationCount == iterationParams.getCount()) {
+            Path profileFile = outputFile(benchmarkParams);
+            profilerCommand("stop", "-f", profileFile.toString());
+            generated.add(profileFile);
+        }
+
+        if (generated.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return generated
+                .stream().map(Path::toAbsolutePath)
+                .map(Path::toString)
+                .map(f -> new NoResult("flame-graph", f))
+                .collect(Collectors.toList());
+    }
+
+    private Path createTempDir(final BenchmarkParams benchmarkParams) {
+        String benchmark = benchmarkParams.getBenchmark();
+        int i = benchmark.lastIndexOf('.');
+        if (i > 0) {
+            benchmark = benchmark.substring(0, i);
+        }
+        try {
+            return LdbcDownloader.tempDirFor("org.neo4j", "bench", benchmark);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final Pattern SLASH = Pattern.compile("/");
+
+    private Path outputFile(final BenchmarkParams benchmarkParams) {
+        return outputDir.resolve(outputFileName(benchmarkParams)).toAbsolutePath();
+    }
+
+    private String outputFileName(final BenchmarkParams benchmarkParams) {
+        String benchmark = benchmarkParams.getBenchmark();
+        int i = benchmark.lastIndexOf('.');
+        StringBuilder sb = new StringBuilder("profile-");
+        if (i > 0) {
+            sb.append(benchmark, i + 1, benchmark.length()).append("-");
+        }
+        sb.append(event).append("-").append(benchmarkParams.getMode());
+        for (String key : benchmarkParams.getParamsKeys()) {
+            sb
+                    .append("-")
+                    .append(key)
+                    .append("-")
+                    .append(benchmarkParams.getParam(key));
+        }
+        sb.append(".svg");
+        return SLASH.matcher(sb).replaceAll("-");
+    }
+
+    private void profilerCommand(final String action, final String... options) {
+        profilerCommand(action, Arrays.asList(options));
+    }
+
+    private void profilerCommand(final String action, final Collection<String> options) {
+        long pid = Utils.getPid();
+
+        List<String> cmd = new ArrayList<>();
+        cmd.add("./profiler.sh");
+        cmd.add(action);
+        cmd.addAll(options);
+        cmd.add(String.valueOf(pid));
+
+        ProcessBuilder processBuilder = new ProcessBuilder(cmd);
+        processBuilder.directory(asyncProfilerDir.toFile());
+        startAndWait(processBuilder);
+    }
+
+    private void createOutputDirectories() {
+        createDirectories(outputDir);
+    }
+
+    private static OptionSet parseInitLine(final String initLine, final OptionParser parser) throws ProfilerException {
+        try {
+            Method method = Class
+                    .forName("org.openjdk.jmh.profile.ProfilerUtils")
+                    .getDeclaredMethod("parseInitLine", String.class, OptionParser.class);
+            method.setAccessible(true);
+            return (OptionSet) method.invoke(null, initLine, parser);
+        } catch (InvocationTargetException ex) {
+            throw (ProfilerException) ex.getCause();
+        } catch (NoSuchMethodException | IllegalArgumentException | IllegalAccessException | ClassNotFoundException | SecurityException e) {
+            throw new ProfilerException(e);
+        }
+    }
+
+    private static void startAndWait(final ProcessBuilder processBuilder) {
+        String commandLine = String.join(" ", processBuilder.command());
+        try {
+            processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+            Process process = processBuilder.start();
+            if (process.waitFor() != 0) {
+                throw new RuntimeException("Non zero exit code from: " + commandLine);
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Error running " + commandLine, e);
+        }
+    }
+
+    private static void createDirectories(final Path outputDir) {
+        try {
+            Files.createDirectories(outputDir);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
+++ b/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
@@ -247,7 +247,7 @@ public final class FlameGraph implements InternalProfiler, ExternalProfiler {
 
         if (++measurementIterationCount == iterationParams.getCount()) {
             Path profileFile = outputFile(benchmarkParams);
-            profilerCommand("stop", "-f", profileFile.toString());
+            profilerCommand("stop", Arrays.asList("-f", profileFile.toString()));
             generated.add(profileFile);
         }
 
@@ -298,10 +298,6 @@ public final class FlameGraph implements InternalProfiler, ExternalProfiler {
         }
         sb.append(".svg");
         return SLASH.matcher(sb).replaceAll("-");
-    }
-
-    private void profilerCommand(final String action, final String... options) {
-        profilerCommand(action, Arrays.asList(options));
     }
 
     private void profilerCommand(final String action, final Collection<String> options) {

--- a/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
+++ b/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
@@ -33,6 +33,29 @@ import java.util.OptionalLong;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Runs the <a href="https://github.com/jvm-profiling-tools/async-profiler">async-profiler</a>
+ * alongside the profiled benchmark and produces a flame graph of the profiling result.
+ *
+ * Run the benchmarks with {@code -prof org.neo4j.prof.FlameGraph} to enable this profiler.
+ *
+ * You have to <a href="https://github.com/jvm-profiling-tools/async-profiler/releases">download the async-profiler</a>
+ * and point the profiler to the profiler directory. This can be done either by setting
+ * the ENV variable ASYNC_PROFILER_DIR to the /path/to/async-profiler or by passing the
+ * directory to the {@code asyncProfiler} option, e.g. {@code -prof org.neo4j.prof.FlameGraph:asyncProfiler=/path/to/async-profiler}.
+ * The profiler must be at least version 1.2 with the added SVG support.
+ *
+ * Flame graph files are by default put into the {@code $TMP/org.neo4j/bench/$BENCHMARK_CLASS/} folder
+ * where {@code $TMP} is defined as the {@link System#getProperty(String) SystemProperty} {@code java.io.tmp}
+ * and {@code $BENCHMARK_CLASS} is the unqualified class name of the benchmark under profiling.
+ * This directory can be override by providing the {@code dir} option.
+ *
+ * The file name is derived from the benchmark method and its parameters.
+ *
+ * Run with {@code -prof org.neo4j.prof.FlameGraph:help} to see all possible options.
+ *
+ * @see <a href="https://github.com/jvm-profiling-tools/async-profiler">async-profiler</a>
+ */
 public final class FlameGraph implements InternalProfiler, ExternalProfiler {
 
     private static final String ASYNC_PROFILER_DIR = "ASYNC_PROFILER_DIR";

--- a/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
+++ b/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
@@ -66,7 +66,7 @@ public final class FlameGraph implements InternalProfiler, ExternalProfiler {
         ArgumentAcceptingOptionSpec<String> asyncProfiler = parser
                 .accepts(
                         "asyncProfiler",
-                        "Location of https://github.com/jvm-profiling-tools/async-profiler unless procived by $" + ASYNC_PROFILER_DIR)
+                        "Location of https://github.com/jvm-profiling-tools/async-profiler unless provided by $" + ASYNC_PROFILER_DIR)
                 .withRequiredArg()
                 .ofType(String.class)
                 .describedAs("directory");

--- a/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
+++ b/benchmark/src/main/java/org/neo4j/prof/FlameGraph.java
@@ -128,6 +128,19 @@ public final class FlameGraph implements InternalProfiler, ExternalProfiler {
         }
     }
 
+    public FlameGraph() {
+        Path asyncDir = null;
+        String env = System.getenv(ASYNC_PROFILER_DIR);
+        if (env != null) {
+            asyncDir = Paths.get(env).toAbsolutePath();
+        }
+        this.event = DEFAULT_EVENT;
+        this.frameBufferSize = OptionalLong.empty();
+        this.interval = OptionalLong.empty();
+        this.threads = false;
+        this.asyncProfilerDir = asyncDir;
+    }
+
     @Override
     public Collection<String> addJVMInvokeOptions(final BenchmarkParams params) {
         return Collections.emptyList();
@@ -171,7 +184,7 @@ public final class FlameGraph implements InternalProfiler, ExternalProfiler {
 
     @Override
     public void beforeIteration(final BenchmarkParams benchmarkParams, final IterationParams iterationParams) {
-        if (iterationParams.getType() != IterationType.MEASUREMENT || started) {
+        if (iterationParams.getType() != IterationType.MEASUREMENT || started || asyncProfilerDir == null) {
             return;
         }
 

--- a/benchmark/src/main/java/org/neo4j/prof/JFR.java
+++ b/benchmark/src/main/java/org/neo4j/prof/JFR.java
@@ -20,18 +20,13 @@ package org.neo4j.prof;
 
 import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.profile.ExternalProfiler;
-import org.openjdk.jmh.results.AggregationPolicy;
-import org.openjdk.jmh.results.Aggregator;
 import org.openjdk.jmh.results.BenchmarkResult;
 import org.openjdk.jmh.results.Result;
-import org.openjdk.jmh.results.ResultRole;
-import org.openjdk.jmh.util.SingletonStatistics;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 /**
  * Runs Java Flight Recorder during JMH benchmarking.
@@ -95,53 +90,5 @@ public final class JFR implements ExternalProfiler {
 
     private String getFileName(final BenchmarkParams params) {
         return params.id().replaceAll("['\"]", "-") + ".jfr";
-    }
-
-    private static final class NoResult extends Result<NoResult> {
-
-        private final String label;
-        private final String output;
-
-        private NoResult(final String label, final String output) {
-            super(
-                    ResultRole.SECONDARY,
-                    label,
-                    new SingletonStatistics(Double.NaN),
-                    "N/A",
-                    AggregationPolicy.SUM);
-            this.label = label;
-            this.output = output;
-        }
-
-        String output() {
-            return output;
-        }
-
-        @Override
-        protected Aggregator<NoResult> getThreadAggregator() {
-            return new NoResultAggregator();
-        }
-
-        @Override
-        protected Aggregator<NoResult> getIterationAggregator() {
-            return new NoResultAggregator();
-        }
-
-        @Override
-        public String extendedInfo() {
-            return output;
-        }
-    }
-
-    private static final class NoResultAggregator implements Aggregator<NoResult> {
-        @Override
-        public NoResult aggregate(final Collection<NoResult> results) {
-            return new NoResult(
-                    results.iterator().next().label,
-                    results.stream()
-                            .map(NoResult::output)
-                            .collect(Collectors.joining(System.lineSeparator()))
-            );
-        }
     }
 }

--- a/benchmark/src/main/java/org/neo4j/prof/NoResult.java
+++ b/benchmark/src/main/java/org/neo4j/prof/NoResult.java
@@ -1,0 +1,58 @@
+package org.neo4j.prof;
+
+import org.openjdk.jmh.results.AggregationPolicy;
+import org.openjdk.jmh.results.Aggregator;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.ResultRole;
+import org.openjdk.jmh.util.SingletonStatistics;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+final class NoResult extends Result<NoResult> {
+
+    private final String label;
+    private final String output;
+
+    NoResult(final String label, final String output) {
+        super(
+                ResultRole.SECONDARY,
+                label,
+                new SingletonStatistics(Double.NaN),
+                "N/A",
+                AggregationPolicy.SUM);
+        this.label = label;
+        this.output = output;
+    }
+
+    String output() {
+        return output;
+    }
+
+    @Override
+    protected Aggregator<NoResult> getThreadAggregator() {
+        return new NoResultAggregator();
+    }
+
+    @Override
+    protected Aggregator<NoResult> getIterationAggregator() {
+        return new NoResultAggregator();
+    }
+
+    @Override
+    public String extendedInfo() {
+        return output;
+    }
+
+    private static final class NoResultAggregator implements Aggregator<NoResult> {
+        @Override
+        public NoResult aggregate(final Collection<NoResult> results) {
+            return new NoResult(
+                    results.iterator().next().label,
+                    results.stream()
+                            .map(NoResult::output)
+                            .collect(Collectors.joining(System.lineSeparator()))
+            );
+        }
+    }
+}

--- a/benchmark/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
+++ b/benchmark/src/main/resources/META-INF/services/org.openjdk.jmh.profile.Profiler
@@ -1,2 +1,3 @@
 org.neo4j.prof.JFR
 org.neo4j.prof.Heap
+org.neo4j.prof.FlameGraph

--- a/core/src/main/java/org/neo4j/graphalgo/helper/ldbc/LdbcDownloader.java
+++ b/core/src/main/java/org/neo4j/graphalgo/helper/ldbc/LdbcDownloader.java
@@ -137,7 +137,7 @@ public final class LdbcDownloader {
         }
     }
 
-    private static Path tempDirFor(String... subDirs) throws IOException {
+    public static Path tempDirFor(String... subDirs) throws IOException {
         Path tmpDir = getDefaultTempDir().toAbsolutePath();
         for (String subDir : subDirs) {
             tmpDir = tmpDir.resolve(subDir);


### PR DESCRIPTION
To enable it, run the benchmarks with `-prof org.neo4j.prof.FlameGraph`.
You have to download the [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) and point to its location with `ASYNC_PROFILER_DIR=/path/to/async-profiler` or by using the `asyncProfiler` option.
Per default, the output files are saved under /tmp (or wherever java.io.tmp points to) in the org.neo4j/bench subdirectory, grouped by the benchmark class.
Run with `-prof org.neo4j.prof.FlameGraph:help` to see all possible options.