### PR TITLE
Fixed calculation of denominator for Jaccard-similarity

### DIFF
--- a/algo/src/main/java/org/neo4j/graphalgo/similarity/Similarities.java
+++ b/algo/src/main/java/org/neo4j/graphalgo/similarity/Similarities.java
@@ -45,10 +45,14 @@ public class Similarities {
         if (vector1 == null || vector2 == null) return 0;
 
         HashSet<Number> intersectionSet = new HashSet<>(vector1);
+
+        // add size of vector1 and vector2 (ignoring duplicates) before calling retainAll(vector2)
+        long denom_sum = intersectionSet.size() + new HashSet<>(vector2).size();
+
         intersectionSet.retainAll(vector2);
         int intersection = intersectionSet.size();
 
-        long denominator = vector1.size() + vector2.size() - intersection;
+        long denominator = denom_sum - intersection;
         return denominator == 0 ? 0 : (double) intersection / denominator;
     }
 

--- a/algo/src/test/java/org/neo4j/graphalgo/similarity/SimilaritiesTest.java
+++ b/algo/src/test/java/org/neo4j/graphalgo/similarity/SimilaritiesTest.java
@@ -1,0 +1,91 @@
+package org.neo4j.graphalgo.similarity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(Parameterized.class)
+public class SimilaritiesTest {
+
+    private final List<Number> input;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<List<Number>> data() {
+        return Arrays.asList(
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(1, 2, 3, 3),
+                Arrays.asList(104, 101, 108, 108, 111)
+        );
+    }
+
+    public SimilaritiesTest(List<Number> input) {
+        this.input = input;
+    }
+
+    @Test
+    public void jaccardIdenticalInput() {
+        // given identical input
+
+        // when
+        Similarities s = new Similarities();
+        double result = s.jaccardSimilarity(input, input);
+
+        // then
+        assertEquals(1.0, result, 0.01);
+    }
+
+    @Test
+    public void cosineIdenticalInput() {
+        // given identical input
+
+        // when
+        Similarities s = new Similarities();
+        double result = s.cosineSimilarity(input, input);
+
+        // then
+        assertEquals(1.0, result, 0.01);
+    }
+
+    @Test
+    public void pearsonIdenticalInput() {
+        // given identical input
+
+        // when
+        Similarities s = new Similarities();
+        double result = s.pearsonSimilarity(input, input, Collections.emptyMap());
+
+        // then
+        assertEquals(1.0, result, 0.01);
+    }
+
+    @Test
+    public void euclideanIdenticalInput() {
+        // given identical input
+
+        // when
+        Similarities s = new Similarities();
+        double result = s.euclideanSimilarity(input, input);
+
+        // then
+        assertEquals(1.0, result, 0.01);
+    }
+
+    @Test
+    public void overlapIdenticalInput() {
+        // given identical input
+
+        // when
+        Similarities s = new Similarities();
+        double result = s.euclideanSimilarity(input, input);
+
+        // then
+        assertEquals(1.0, result, 0.01);
+    }
+}


### PR DESCRIPTION
The current implementation of Jaccard-similarity doesn't discard dupliate input values when calculating the denominator. I identified this issue by calculating Jaccard on identical input containing duplicates which didn't return `1.0` for which I added test cases.